### PR TITLE
Update CI to build macOS App bundle properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,7 +222,8 @@ jobs:
           plutil -lint ./scripts/Info.plist
           mkdir -p SystemBridge.app/Contents/{MacOS,Resources}
           cp scripts/Info.plist SystemBridge.app/Contents
-          cp -R out/* SystemBridge.app/Contents/Resources
+          cp out/{system-bridge,system-bridge-tray,xdg-open,traybin/tray_darwin_release} SystemBridge.app/Contents/MacOS
+          cp -R out/system-bridge-circle.* SystemBridge.app/Contents/Resources
           npx appdmg appdmg.json SystemBridge.dmg
       - name: ⬆ Upload Artifacts - MacOS dmg
         if: matrix.os.platform == 'darwin'

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ junit.xml
 *setup.exe
 *.deb
 *.rpm
+*.dmg
+*.app


### PR DESCRIPTION
![an orange and white cat reading a book on military strategy, flipping pages itself with it's paw](https://media.giphy.com/media/NFA61GS9qKZ68/giphy.gif)

# Proposed Changes

Taking a look at the [dev docs](https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html#//apple_ref/doc/uid/10000123i-CH101-SW19), it appears that the `MacOS` directory is where executables need to land, with supporting assets only in `Content/Resources`.

I wasn't clear if only `system-bridge` needed to be copied, so I took anything that was executable and threw it in `Resources/MacOS` for good measure. This could easily be paired down as necessary.

## Related Issues

https://github.com/timmo001/system-bridge/issues/464

## Checklist

- [x] Get properly recognized App Bundle
- [ ] Test on Intel Mac
- [ ] Test on M1

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->
