### PR TITLE
Fix paths

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ config();
 
 const PATH_API = join(__dirname, "components/api/index.js");
 const PATH_TRAY = join(__dirname, "../tray/dist/index.js");
+const PATH_EXE = join(dirname(process.execPath), "system-bridge.exe");
 const PATH_TRAY_EXE = join(dirname(process.execPath), "system-bridge-tray.exe");
 
 const DEFAULT_ENV = {
@@ -68,7 +69,10 @@ function setupSubprocess(name: string): ExecaChildProcess | null {
       return null;
     case "api":
       logger.info(`PATH_API: ${PATH_API}`);
-      subprocess = execa.node(PATH_API, [], DEFAULT_OPTIONS);
+      subprocess =
+        process.env.SB_PACKAGED !== "false"
+          ? execa(PATH_EXE, [PATH_API], DEFAULT_EXE_OPTIONS)
+          : execa.node(PATH_API, [], DEFAULT_OPTIONS);
       break;
     case "tray":
       logger.info(


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The API was being attempted to be launched with `execa.node` instead of launching the prebuilt system-bridge.exe which has node built in.

On my (dev) machines, I have node installed, but on other machines, this may not be the case. Now node will not be required as it should have been and the API will be launched as a subprocess alongside the tray (if enabled)

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Fixes #869 

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
