### PR TITLE
Replace all usages of | in type strings for Python 3.9 compat

### DIFF
--- a/backend/systembridgebackend/modules/battery/__init__.py
+++ b/backend/systembridgebackend/modules/battery/__init__.py
@@ -1,6 +1,8 @@
 """System Bridge: Battery"""
 from __future__ import annotations
 
+from typing import Optional
+
 from plyer import battery
 import psutil
 from systembridgeshared.base import Base
@@ -9,7 +11,7 @@ from systembridgeshared.base import Base
 class Battery(Base):
     """Battery"""
 
-    def sensors(self) -> psutil._common.sfan | None:
+    def sensors(self) -> Optional[psutil._common.sfan]:
         """Get battery sensors"""
         if not hasattr(psutil, "sensors_battery"):
             return None

--- a/backend/systembridgebackend/modules/cpu/__init__.py
+++ b/backend/systembridgebackend/modules/cpu/__init__.py
@@ -1,6 +1,8 @@
 """System Bridge: CPU"""
 from __future__ import annotations
 
+from typing import Optional
+
 from psutil import (
     cpu_count,
     cpu_freq,
@@ -49,7 +51,7 @@ class CPU(Base):
     def temperature(
         self,
         database: Database,
-    ) -> float | None:
+    ) -> Optional[float]:
         """CPU temperature"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if item[COLUMN_HARDWARE_TYPE] is not None and (
@@ -101,7 +103,7 @@ class CPU(Base):
     def voltage(
         self,
         database: Database,
-    ) -> float | None:
+    ) -> Optional[float]:
         """CPU voltage"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (

--- a/backend/systembridgebackend/modules/disk/__init__.py
+++ b/backend/systembridgebackend/modules/disk/__init__.py
@@ -1,7 +1,7 @@
 """System Bridge: Disk"""
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 from psutil import disk_io_counters, disk_partitions, disk_usage
 from psutil._common import sdiskio, sdiskpart
@@ -23,7 +23,7 @@ class Disk(Base):
         """Disk partitions"""
         return disk_partitions(all=True)
 
-    def usage(self, path: str) -> NamedTuple | None:
+    def usage(self, path: str) -> Optional[NamedTuple]:
         """Disk usage"""
         try:
             return disk_usage(path)

--- a/backend/systembridgebackend/modules/display/__init__.py
+++ b/backend/systembridgebackend/modules/display/__init__.py
@@ -1,6 +1,8 @@
 """System Bridge: Display"""
 from __future__ import annotations
 
+from typing import Optional
+
 from systembridgeshared.base import Base
 from systembridgeshared.common import make_key
 from systembridgeshared.const import (
@@ -36,7 +38,7 @@ class Display(Base):
         self,
         database: Database,
         display_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """Display pixel clock"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -58,7 +60,7 @@ class Display(Base):
         self,
         database: Database,
         display_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """Display refresh rate"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -80,7 +82,7 @@ class Display(Base):
         self,
         database: Database,
         display_key: str,
-    ) -> int | None:
+    ) -> Optional[int]:
         """Display resolution horizontal"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -102,7 +104,7 @@ class Display(Base):
         self,
         database: Database,
         display_key: str,
-    ) -> int | None:
+    ) -> Optional[int]:
         """Display resolution vertical"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (

--- a/backend/systembridgebackend/modules/gpu/__init__.py
+++ b/backend/systembridgebackend/modules/gpu/__init__.py
@@ -1,6 +1,8 @@
 """System Bridge: GPU"""
 from __future__ import annotations
 
+from typing import Optional
+
 from systembridgeshared.base import Base
 from systembridgeshared.common import make_key
 from systembridgeshared.const import (
@@ -36,7 +38,7 @@ class GPU(Base):
         self,
         database: Database,
         gpu_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """GPU core clock"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -58,7 +60,7 @@ class GPU(Base):
         self,
         database: Database,
         gpu_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """GPU core load"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -78,7 +80,7 @@ class GPU(Base):
         self,
         database: Database,
         gpu_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """GPU fan speed"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -97,7 +99,7 @@ class GPU(Base):
         self,
         database: Database,
         gpu_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """GPU memory clock"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -119,7 +121,7 @@ class GPU(Base):
         self,
         database: Database,
         gpu_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """GPU memory load"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -141,7 +143,7 @@ class GPU(Base):
         self,
         database: Database,
         gpu_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """GPU memory free"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -163,7 +165,7 @@ class GPU(Base):
         self,
         database: Database,
         gpu_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """GPU memory used"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -185,7 +187,7 @@ class GPU(Base):
         self,
         database: Database,
         gpu_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """GPU memory total"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -207,7 +209,7 @@ class GPU(Base):
         self,
         database: Database,
         gpu_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """GPU power usage"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (
@@ -226,7 +228,7 @@ class GPU(Base):
         self,
         database: Database,
         gpu_key: str,
-    ) -> float | None:
+    ) -> Optional[float]:
         """GPU temperature"""
         for item in database.read_table("sensors").to_dict(orient="records"):
             if (

--- a/backend/systembridgebackend/modules/sensors/__init__.py
+++ b/backend/systembridgebackend/modules/sensors/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from typing import Optional, Dict
 
 import psutil
 from systembridgeshared.base import Base
@@ -12,19 +13,19 @@ from systembridgeshared.base import Base
 class Sensors(Base):
     """Sensors"""
 
-    def fans(self) -> dict | None:
+    def fans(self) -> Optional[Dict]:
         """Get fans"""
         if not hasattr(psutil, "sensors_fans"):
             return None
         return psutil.sensors_fans()  # type: ignore
 
-    def temperatures(self) -> dict | None:
+    def temperatures(self) -> Optional[Dict]:
         """Get temperatures"""
         if not hasattr(psutil, "sensors_temperatures"):
             return None
         return psutil.sensors_temperatures()  # type: ignore
 
-    def windows_sensors(self) -> dict | None:
+    def windows_sensors(self) -> Optional[Dict]:
         """Get windows sensors"""
         if sys.platform != "win32":
             return None

--- a/backend/systembridgebackend/modules/system/__init__.py
+++ b/backend/systembridgebackend/modules/system/__init__.py
@@ -5,6 +5,7 @@ import os
 import platform
 import re
 import socket
+from typing import Optional
 import uuid
 
 from aiogithubapi import (
@@ -74,7 +75,7 @@ class System(Base):
         """Get version"""
         return __version__.public()
 
-    async def version_latest(self) -> GitHubReleaseModel | None:
+    async def version_latest(self) -> Optional[GitHubReleaseModel]:
         """Get latest version from GitHub"""
         self._logger.info("Get latest version from GitHub")
         try:
@@ -95,7 +96,7 @@ class System(Base):
     def version_newer_available(
         self,
         database: Database,
-    ) -> bool | None:
+    ) -> Optional[bool]:
         """Check if newer version is available"""
         version = database.read_table_by_key("system", "version").to_dict(
             orient="records"

--- a/backend/systembridgebackend/server/media.py
+++ b/backend/systembridgebackend/server/media.py
@@ -10,6 +10,7 @@ import os
 import re
 import tempfile
 from urllib.parse import urlencode
+from typing import Optional, Dict
 
 import aiofiles
 from aiohttp import ClientSession
@@ -103,7 +104,7 @@ def get_files(
 def get_file(
     base_path: str,
     filepath: str,
-) -> dict | None:
+) -> Optional[Dict]:
     """Get file from path"""
     try:
         stat = os.stat(filepath)
@@ -590,7 +591,7 @@ async def _delete_cover_delayed(
 def _save_cover_from_binary(
     data: bytes,
     mime_type: str,
-    name: str | None,
+    name: Optional[str],
 ) -> str:
     """Save cover from binary."""
     cover_extension = mimetypes.guess_extension(mime_type)

--- a/cli/systembridgecli/__main__.py
+++ b/cli/systembridgecli/__main__.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 from uuid import uuid4
+from typing import Optional
 
 from systembridgeshared.common import get_user_data_directory
 from systembridgeshared.const import SECRET_API_KEY, SETTING_PORT_API, TABLE_SETTINGS
@@ -71,7 +72,7 @@ def settings_all():
 def setting(
     key: str,
     set_value: bool = False,
-    value: str | None = None,
+    value: Optional[str] = None,
 ) -> None:
     """Get or Set Setting"""
     if set_value:
@@ -86,7 +87,7 @@ def setting(
 def secret(
     key: str,
     set_value: bool = False,
-    value: str | None = None,
+    value: Optional[str] = None,
 ) -> None:
     """Get or Set Secret"""
     if set_value:

--- a/connector/systembridgeconnector/http_client.py
+++ b/connector/systembridgeconnector/http_client.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
+from typing import Any, Optional
 
 from aiohttp import ClientResponse, ClientSession
 from aiohttp.client_exceptions import ClientConnectorError, ServerDisconnectedError
@@ -27,7 +27,7 @@ class HTTPClient(Base):
         api_host: str,
         api_port: int,
         api_key: str,
-        session: ClientSession | None = None,
+        session: Optional[ClientSession] = None,
     ) -> None:
         """Initialize the client."""
         super().__init__()
@@ -55,7 +55,7 @@ class HTTPClient(Base):
     async def post(
         self,
         path: str,
-        payload: Any | None,
+        payload: Optional[Any],
     ) -> Any:
         """Make a POST request"""
         response: ClientResponse = await self.request(
@@ -72,7 +72,7 @@ class HTTPClient(Base):
     async def put(
         self,
         path: str,
-        payload: Any | None,
+        payload: Optional[Any],
     ) -> Any:
         """Make a PUT request"""
         response: ClientResponse = await self.request(

--- a/connector/systembridgeconnector/version.py
+++ b/connector/systembridgeconnector/version.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from aiohttp import ClientSession
 from pkg_resources import parse_version
+from typing import Optional
 
 from systembridgeconnector.base import Base
 from systembridgeconnector.exceptions import ConnectionErrorException
@@ -20,7 +21,7 @@ class Version(Base):
         api_host: str,
         api_port: int,
         api_key: str,
-        session: ClientSession | None = None,
+        session: Optional[ClientSession] = None,
     ) -> None:
         """Initialize the client."""
         super().__init__()
@@ -40,7 +41,7 @@ class Version(Base):
             return parse_version(version) >= parse_version(SUPPORTED_VERSION)
         return False
 
-    async def check_version_2(self) -> str | None:
+    async def check_version_2(self) -> Optional[str]:
         """Check if the system is running v2.x.x version."""
         try:
             information = await self._http_client.get("/information")
@@ -63,7 +64,7 @@ class Version(Base):
             raise exception
         return None
 
-    async def check_version_3(self) -> str | None:
+    async def check_version_3(self) -> Optional[str]:
         """Check if the system is running v3.x.x version."""
         try:
             response = await self._http_client.get("/api/data/system")

--- a/connector/systembridgeconnector/websocket_client.py
+++ b/connector/systembridgeconnector/websocket_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 import socket
-from typing import Any
+from typing import Any, Optional, Dict
 from uuid import uuid4
 
 import aiohttp
@@ -79,9 +79,9 @@ class WebSocketClient(Base):
         self._api_host = api_host
         self._api_port = api_port
         self._api_key = api_key
-        self._responses: dict[str, tuple[asyncio.Future, str | None]] = {}
-        self._session: aiohttp.ClientSession | None = None
-        self._websocket: aiohttp.ClientWebSocketResponse | None = None
+        self._responses: dict[str, tuple[asyncio.Future, Optional[str]]] = {}
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._websocket: Optional[aiohttp.ClientWebSocketResponse] = None
 
     @property
     def connected(self) -> bool:
@@ -127,7 +127,7 @@ class WebSocketClient(Base):
 
     async def connect(
         self,
-        session: aiohttp.ClientSession | None = None,
+        session: Optional[aiohttp.ClientSession] = None,
     ) -> None:
         """Connect to server"""
         if session:
@@ -397,7 +397,7 @@ class WebSocketClient(Base):
 
     async def listen(
         self,
-        callback: Callable[[str, Any], Awaitable[None]] | None = None,
+        callback: Optional[Callable[[str, Any], Awaitable[None]]] = None,
         accept_other_types: bool = False,
     ) -> None:
         """Listen for messages and map to modules"""
@@ -489,7 +489,7 @@ class WebSocketClient(Base):
                 if isinstance(message, dict):
                     await callback(message)
 
-    async def receive_message(self) -> dict | None:
+    async def receive_message(self) -> Optional[Dict]:
         """Receive message"""
         if not self.connected or self._websocket is None:
             raise ConnectionClosedException("Connection is closed")

--- a/gui/systembridgegui/__main__.py
+++ b/gui/systembridgegui/__main__.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import os
 import sys
+from typing import Optional, Dict
 
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QApplication, QMessageBox
@@ -38,7 +39,7 @@ class Main(Base):
         self,
         command: str = "main",
         gui_only: bool = False,
-        data: dict | None = None,
+        data: Optional[Dict] = None,
     ) -> None:
         """Initialize"""
         super().__init__()
@@ -144,8 +145,8 @@ class Main(Base):
         self,
         path: str,
         maximized: bool,
-        width: int | None = 1280,
-        height: int | None = 720,
+        width: Optional[int] = 1280,
+        height: Optional[int] = 720,
     ) -> None:
         """Show the main window"""
         self._logger.info("Showing window: %s", path)

--- a/gui/systembridgegui/system_tray.py
+++ b/gui/systembridgegui/system_tray.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections.abc import Callable
 import os
 from webbrowser import open_new_tab
+from typing import Optional
 
 from PySide6.QtGui import QAction, QCursor, QIcon
 from PySide6.QtWidgets import QApplication, QMenu, QSystemTrayIcon
@@ -35,7 +36,7 @@ class SystemTray(Base, QSystemTrayIcon):
         icon: QIcon,
         parent: QApplication,
         callback_exit_application: Callable,
-        callback_show_window: Callable[[str, bool, int | None, int | None], None],
+        callback_show_window: Callable[[str, bool, Optional[int], Optional[int]], None],
     ) -> None:
         """Initialize the system tray"""
         Base.__init__(self)

--- a/shared/systembridgeshared/common.py
+++ b/shared/systembridgeshared/common.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import os
 import re
+from typing import Union
 
 from appdirs import AppDirs
 
@@ -25,7 +26,7 @@ def camel_to_snake(name):
 
 def convert_string_to_correct_type(
     value: str,
-) -> str | int | float | bool | list | dict | None:
+) -> Union[bool, float, int, str, list, dict, None]:
     """Convert string to correct data type"""
     try:
         if value.startswith("'") and value.endswith("'"):

--- a/shared/systembridgeshared/database.py
+++ b/shared/systembridgeshared/database.py
@@ -7,6 +7,7 @@ import json
 import os
 from sqlite3 import OperationalError, connect
 from time import time
+from typing import Optional, Union
 
 from pandas import DataFrame, read_sql_query
 
@@ -164,8 +165,8 @@ class Database(Base):
         self,
         table_name: str,
         data_key: str,
-        data_value: bool | float | int | str | list | dict | None,
-        data_timestamp: float | None = None,
+        data_value: Union[bool, float, int, str, list, dict, None],
+        data_timestamp: Optional[float] = None,
     ) -> None:
         """Write to table"""
         if data_timestamp is None:
@@ -198,8 +199,8 @@ class Database(Base):
         data_name: str,
         data_hardware_type: str,
         data_hardware_name: str,
-        data_value: bool | float | int | str | list | dict | None,
-        data_timestamp: float | None = None,
+        data_value: Union[bool, float, int, str, list, dict, None],
+        data_timestamp: Optional[float] = None,
     ) -> None:
         """Write to table"""
         if data_timestamp is None:
@@ -229,7 +230,7 @@ class Database(Base):
     def table_data_to_ordered_dict(
         self,
         table_name: str,
-    ) -> OrderedDict | None:
+    ) -> Optional[OrderedDict]:
         """Convert table to OrderedDict"""
         data_dict = self.read_table(table_name).to_dict(orient="records")
         if len(data_dict) == 0:

--- a/shared/systembridgeshared/settings.py
+++ b/shared/systembridgeshared/settings.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import io
 import os
 from os.path import exists
+from typing import Union
 from uuid import uuid4
 
 from appdirs import AppDirs
@@ -94,7 +95,7 @@ class Settings(Base):
     def get(
         self,
         key: str,
-    ) -> bool | float | int | str | list | dict | None:
+    ) -> Union[bool, float, int, str, list, dict, None]:
         """Get setting"""
         record = self._database.read_table_by_key(TABLE_SETTINGS, key).to_dict(
             orient="records"
@@ -123,7 +124,7 @@ class Settings(Base):
     def set(
         self,
         key: str,
-        value: bool | float | int | str | list | dict | None,
+        value: Union[bool, float, int, str, list, dict, None],
     ) -> None:
         """Set setting"""
         self._database.write(TABLE_SETTINGS, key, value)

--- a/shared/systembridgeshared/update.py
+++ b/shared/systembridgeshared/update.py
@@ -9,6 +9,7 @@ import platform
 import subprocess
 import sys
 import urllib.request
+from typing import Optional
 
 from systembridgeshared.base import Base
 
@@ -33,7 +34,7 @@ class Update(Base):
             result = pipe.communicate()[0].decode()
         self._logger.info("Result: %s", result)
 
-    def _update(self, packages: dict[str, str | None]) -> None:
+    def _update(self, packages: dict[str, Optional[str]]) -> None:
         """Update each package."""
         for package, version in packages.items():
             self._logger.info("Updating %s to version %s", package, version)
@@ -46,9 +47,9 @@ class Update(Base):
 
     def update(
         self,
-        version: str | None,
+        version: Optional[str],
         wait: bool = False,
-    ) -> dict[str, str | None]:
+    ) -> dict[str, Optional[str]]:
         """Update the application."""
         packages = {
             "systembridgeshared": version,

--- a/shared/systembridgeshared/websocket_client.py
+++ b/shared/systembridgeshared/websocket_client.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import Awaitable, Callable
 import socket
-from typing import Any
+from typing import Any, Optional, Dict
 from uuid import uuid4
 
 import aiohttp
@@ -78,9 +78,9 @@ class WebSocketClient(Base):
         """Initialize"""
         super().__init__()
         self._settings = settings
-        self._responses: dict[str, tuple[asyncio.Future, str | None]] = {}
-        self._session: aiohttp.ClientSession | None = None
-        self._websocket: aiohttp.ClientWebSocketResponse | None = None
+        self._responses: dict[str, tuple[asyncio.Future, Optional[str]]] = {}
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._websocket: Optional[aiohttp.ClientWebSocketResponse] = None
         self._api_key = self._settings.get_secret(SECRET_API_KEY)
 
     @property
@@ -127,7 +127,7 @@ class WebSocketClient(Base):
 
     async def connect(
         self,
-        session: aiohttp.ClientSession | None = None,
+        session: Optional[aiohttp.ClientSession] = None,
     ) -> None:
         """Connect to server"""
         if session:
@@ -397,7 +397,7 @@ class WebSocketClient(Base):
 
     async def listen(
         self,
-        callback: Callable[[str, Any], Awaitable[None]] | None = None,
+        callback: Optional[Callable[[str, Any], Awaitable[None]]] = None,
         accept_other_types: bool = False,
     ) -> None:
         """Listen for messages and map to modules"""
@@ -489,7 +489,7 @@ class WebSocketClient(Base):
                 if isinstance(message, dict):
                     await callback(message)
 
-    async def receive_message(self) -> dict | None:
+    async def receive_message(self) -> Optional[Dict]:
         """Receive message"""
         if not self.connected or self._websocket is None:
             raise ConnectionClosedException("Connection is closed")


### PR DESCRIPTION
# Proposed Changes

Modified all type annotations that used |. Most could be replaced by Optional[], while a few actually needed Union[]. Use of | is Python 3.10+ only, which is not widely used yet. e.g. the latest stable Debian is on 3.9.

## Related Issues

Fixes #1831

At least the first part of it, for me.

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->
