### PR TITLE
Dont import media if not windows

### DIFF
--- a/backend/systembridgebackend/data.py
+++ b/backend/systembridgebackend/data.py
@@ -7,7 +7,6 @@ from threading import Thread
 from systembridgeshared.base import Base
 from systembridgeshared.database import Database
 
-from .modules.media import Media
 from .modules.update import Update
 
 
@@ -43,6 +42,10 @@ class UpdateEventsThread(Thread):
 
         if platform.system() != "Windows":
             return
+
+        from .modules.media import (  # pylint: disable=import-error, import-outside-toplevel
+            Media,
+        )
 
         self._media = Media(
             database,


### PR DESCRIPTION
Fixes unintended import of media which currently only supports Windows SDKs

Fixes #2568 