### PR TITLE
Changed command to restart linux os

### DIFF
--- a/backend/systembridgebackend/utilities/power.py
+++ b/backend/systembridgebackend/utilities/power.py
@@ -33,7 +33,7 @@ def hibernate() -> None:
 def restart() -> None:
     """Restart the system."""
     if sys.platform == "linux":
-        os.system("systemctl restart")
+        os.system("systemctl reboot")
     elif sys.platform == "win32":
         os.system("shutdown /r /t 0")
 


### PR DESCRIPTION
# Proposed Changes

Currently `systemctl restart` command gives error `Too few arguments`. That's because restart command is being used for restarting services, not OS, and the missing argument is service name. The proper command to restart linux OS is `systemctl reboot`. 

## Related Issues

> (GitHub link to related issues or pull requests)

## Checklist

<!-- Remember! You can check these boxes later after posting your PR -->

- [x] Change has been tested and works on my device(s).

<!-- All other checks are handled by the CI server as preflight checks.
     Make sure to fix any errors found.
     Your PR will not be merged if fixable errors are not resolved -->
