### PR TITLE
Send only updates to subscribed modules

### DIFF
--- a/backend/websocket/handlers.go
+++ b/backend/websocket/handlers.go
@@ -148,16 +148,14 @@ func (ws *WebsocketServer) BroadcastModuleUpdate(module types.Module, addr *stri
 			log.Debug("WS: Broadcasting module update to connection", "addr", *addr, "module", module.Name)
 			ws.SendMessage(conn, response)
 		} else {
-			if len(ws.connections) > 0 {
-				for remote_addr, conn := range ws.connections {
-					modules, ok := ws.dataListeners[remote_addr]
+			for remote_addr, conn := range ws.connections {
+				modules, ok := ws.dataListeners[remote_addr]
 
-					if ok && slices.Contains(modules, module.Name) {
-						log.Debug("WS: Broadcasting module update to listener", "addr", remote_addr, "module", module.Name)
-						ws.SendMessage(conn, response)
-					}
-
+				if ok && slices.Contains(modules, module.Name) {
+					log.Debug("WS: Broadcasting module update to listener", "addr", remote_addr, "module", module.Name)
+					ws.SendMessage(conn, response)
 				}
+
 			}
 		}
 	}

--- a/backend/websocket/handlers.go
+++ b/backend/websocket/handlers.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
 
 	"github.com/charmbracelet/log"
 	"github.com/gorilla/websocket"
@@ -75,14 +76,21 @@ func (ws *WebsocketServer) handleMessages(conn *websocket.Conn) {
 func (ws *WebsocketServer) AddConnection(conn *websocket.Conn) {
 	ws.mutex.Lock()
 	defer ws.mutex.Unlock()
-	ws.connections[conn] = true
+
+	// close connection if remote addr tries to connect again
+	if connection, ok := ws.connections[conn.RemoteAddr().String()]; ok {
+		ws.RemoveConnection(connection)
+		_ = connection.Close()
+	}
+
+	ws.connections[conn.RemoteAddr().String()] = conn
 }
 
 // RemoveConnection removes a WebSocket connection
 func (ws *WebsocketServer) RemoveConnection(conn *websocket.Conn) {
 	ws.mutex.Lock()
 	defer ws.mutex.Unlock()
-	delete(ws.connections, conn)
+	delete(ws.connections, conn.RemoteAddr().String())
 	delete(ws.dataListeners, conn.RemoteAddr().String())
 }
 
@@ -94,30 +102,30 @@ const (
 )
 
 // RegisterDataListener allows a client to receive module data updates
-func (ws *WebsocketServer) RegisterDataListener(connection string, modules []types.ModuleName) RegisterResponse {
+func (ws *WebsocketServer) RegisterDataListener(addr string, modules []types.ModuleName) RegisterResponse {
 	ws.mutex.Lock()
 	defer ws.mutex.Unlock()
 
-	if _, ok := ws.dataListeners[connection]; ok {
+	if _, ok := ws.dataListeners[addr]; ok {
 		return RegisterResponseExists
 	}
 
-	log.Infof("Registering data listener for %s", connection)
-	ws.dataListeners[connection] = modules
+	log.Infof("Registering data listener for %s", addr)
+	ws.dataListeners[addr] = modules
 	return RegisterResponseAdded
 }
 
 // UnregisterDataListener allows a client to stop receiving module data updates
-func (ws *WebsocketServer) UnregisterDataListener(connection string) {
+func (ws *WebsocketServer) UnregisterDataListener(addr string) {
 	ws.mutex.Lock()
 	defer ws.mutex.Unlock()
 
-	log.Infof("Unregistering data listener for %s", connection)
-	delete(ws.dataListeners, connection)
+	log.Infof("Unregistering data listener for %s", addr)
+	delete(ws.dataListeners, addr)
 }
 
 // BroadcastModuleUpdate sends a module data update to all connected clients
-func (ws *WebsocketServer) BroadcastModuleUpdate(module types.Module, connection *string) {
+func (ws *WebsocketServer) BroadcastModuleUpdate(module types.Module, addr *string) {
 	ws.mutex.RLock()
 	defer ws.mutex.RUnlock()
 
@@ -135,18 +143,20 @@ func (ws *WebsocketServer) BroadcastModuleUpdate(module types.Module, connection
 		log.Info("Broadcasting module update", "module", module.Name)
 	}
 
-	for conn := range ws.connections {
-		if connection != nil {
-			log.Info("WS: Broadcasting module update to connection", "connection", *connection, "module", module.Name)
+	if addr != nil {
+		if conn, ok := ws.connections[*addr]; ok {
+			log.Debug("WS: Broadcasting module update to connection", "addr", *addr, "module", module.Name)
 			ws.SendMessage(conn, response)
 		} else {
-			log.Info("WS: Broadcasting module update to all listeners", "module", module.Name)
-			for _, modules := range ws.dataListeners {
-				for _, m := range modules {
-					if m == module.Name {
-						log.Info("WS: Broadcasting module update to listener", "listener", m, "module", module.Name)
+			if len(ws.connections) > 0 {
+				for remote_addr, conn := range ws.connections {
+					modules, ok := ws.dataListeners[remote_addr]
+
+					if ok && slices.Contains(modules, module.Name) {
+						log.Debug("WS: Broadcasting module update to listener", "addr", remote_addr, "module", module.Name)
 						ws.SendMessage(conn, response)
 					}
+
 				}
 			}
 		}

--- a/backend/websocket/messages.go
+++ b/backend/websocket/messages.go
@@ -15,7 +15,7 @@ func (ws *WebsocketServer) SendMessage(conn *websocket.Conn, message event.Messa
 		if closeErr := conn.Close(); closeErr != nil {
 			log.Error("Error closing connection:", closeErr)
 		}
-		delete(ws.connections, conn)
+		delete(ws.connections, conn.RemoteAddr().String())
 	}
 }
 

--- a/backend/websocket/websocket.go
+++ b/backend/websocket/websocket.go
@@ -26,7 +26,7 @@ type WebSocketRequest struct {
 type WebsocketServer struct {
 	token         string
 	upgrader      websocket.Upgrader
-	connections   map[*websocket.Conn]bool
+	connections   map[string]*websocket.Conn
 	dataListeners map[string][]types.ModuleName
 	mutex         sync.RWMutex
 	dataStore     *data.DataStore
@@ -36,7 +36,7 @@ type WebsocketServer struct {
 func NewWebsocketServer(settings *settings.Settings, dataStore *data.DataStore, eventRouter *event.MessageRouter) *WebsocketServer {
 	ws := &WebsocketServer{
 		token:         settings.API.Token,
-		connections:   make(map[*websocket.Conn]bool),
+		connections:   make(map[string]*websocket.Conn),
 		dataListeners: make(map[string][]types.ModuleName),
 		dataStore:     dataStore,
 		EventRouter:   eventRouter,


### PR DESCRIPTION
Old code (without logging)

```go
for conn := range ws.connections {
	if connection != nil {
		ws.SendMessage(conn, response)
	} else {
		for _, modules := range ws.dataListeners {
			for _, m := range modules {
				if m == module.Module {
					ws.SendMessage(conn, response)
				}
			}
		}
	}
}

```

We were iterating over the connections and assign it to `conn`. Then we would check the `dataListeners` for their registered modules and at this moment we would send _ANY_ connection this module update even if they hadn't subscribed to it.

In the new code we first get the modules for the current `remote_addr` and then check if the module name is in the registered modules.

```go
for remote_addr, conn := range ws.connections {
	modules, ok := ws.dataListeners[remote_addr]

	if ok && slices.Contains(modules, module.Module) {
			ws.SendMessage(conn, response)
       }

}
```


Additionally i keyed the connections by the same remote address so we store only one connection per remote address. This is still allowing multiple connections from the same host, because the remote address is a combination of host and port.

