### PR TITLE
Fix unrecoverable crash issues

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -27,20 +27,10 @@ type Backend struct {
 	webClientContent *embed.FS
 }
 
-func New(settings *settings.Settings, dataStore *data.DataStore, webClientContent *embed.FS) *Backend {
+func New(settings *settings.Settings, dataStore *data.DataStore, token string, webClientContent *embed.FS) *Backend {
 	// Initialize the EventBus
 	_ = bus.GetInstance()
 	log.Info("EventBus initialized")
-
-	// Load token for WebSocket and HTTP auth
-	token, err := utils.LoadToken()
-	if err != nil {
-		log.Errorf("error loading token: %v", err)
-		token = utils.GenerateToken()
-		if saveErr := utils.SaveToken(token); saveErr != nil {
-			log.Errorf("failed to persist generated token: %v", saveErr)
-		}
-	}
 
 	eventRouter := event.NewMessageRouter()
 	wsServer := websocket.NewWebsocketServer(token, dataStore, eventRouter)

--- a/data/update.go
+++ b/data/update.go
@@ -48,7 +48,7 @@ func NewUpdateTaskProcessor(dataStore *DataStore, tasksPerSecond float64, burstL
 
 // Start begins processing tasks
 func (tp *UpdateTaskProcessor) Start(workerCount int) {
-	for range workerCount {
+	for i := 0; i < workerCount; i++ {
 		tp.wg.Add(1)
 		go tp.worker()
 	}

--- a/event/handler/update-settings.go
+++ b/event/handler/update-settings.go
@@ -2,6 +2,7 @@ package event_handler
 
 import (
 	_ "embed"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -41,7 +42,11 @@ func RegisterUpdateSettingsHandler(router *event.MessageRouter) {
 			DecodeHook: mapstructure.ComposeDecodeHookFunc(
 				func(from, to reflect.Type, data any) (any, error) {
 					if to == reflect.TypeOf(log.Level(0)) && from.Kind() == reflect.String {
-						parsed, err := log.ParseLevel(data.(string))
+						str, ok := data.(string)
+						if !ok {
+							return nil, fmt.Errorf("expected string for log level but got %T", data)
+						}
+						parsed, err := log.ParseLevel(str)
 						if err != nil {
 							return nil, err
 						}

--- a/main.go
+++ b/main.go
@@ -70,14 +70,14 @@ func main() {
 
 					s, err := settings.Load()
 					if err != nil {
-						log.Fatalf("error loading settings: %v", err)
+						return fmt.Errorf("error loading settings: %w", err)
 					}
 
 					log.Debugf("Loaded settings: %v", s)
 
 					token, err := utils.LoadToken()
 					if err != nil {
-						log.Fatalf("error loading token: %v", err)
+						return fmt.Errorf("error loading token: %w", err)
 					}
 
 					log.Infof("Your API token is: %s", token)
@@ -85,7 +85,7 @@ func main() {
 					// Setup data store
 					dataStore, err := data.NewDataStore()
 					if err != nil {
-						log.Fatalf("Failed to create data store: %v", err)
+						return fmt.Errorf("failed to create data store: %w", err)
 					}
 
 					// Create and run backend server with signal-aware context
@@ -149,14 +149,18 @@ func main() {
 	}
 
 	if err := cmd.Run(ctx, os.Args); err != nil {
-		log.Fatalf("error running cmd: %v", err)
+		log.Errorf("error running cmd: %v", err)
 	}
 }
 
 func onReady() {
 	token, err := utils.LoadToken()
 	if err != nil {
-		log.Fatalf("error loading token: %v", err)
+		log.Errorf("error loading token: %v", err)
+		token = utils.GenerateToken()
+		if saveErr := utils.SaveToken(token); saveErr != nil {
+			log.Errorf("failed to persist generated token: %v", saveErr)
+		}
 	}
 
 	// Set tray icon based on OS

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 					}
 
 					// Create and run backend server with signal-aware context
-					b := backend.New(s, dataStore, &webClientContent)
+					b := backend.New(s, dataStore, token, &webClientContent)
 
 					// Show startup notification if requested
 					if cmd.Bool("open-web-client") {
@@ -149,7 +149,10 @@ func main() {
 	}
 
 	if err := cmd.Run(ctx, os.Args); err != nil {
+		// Stop systray if it was started – avoids leaving background goroutine active
+		systray.Quit()
 		log.Errorf("error running cmd: %v", err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Refine error handling to ensure critical startup failures lead to application exit, while other errors are handled gracefully.

This PR distinguishes between truly unrecoverable startup conditions (e.g., missing settings, token, or datastore) which now cause the application to exit with a non-zero status, and less critical issues (e.g., web client serving failure, systray token load) which are logged, allowing the application to continue running in a degraded but stable state. This balances robustness with essential operational requirements.