### PR TITLE
Fix command to specified format with playerctl

### DIFF
--- a/data/module/media/media_linux.go
+++ b/data/module/media/media_linux.go
@@ -4,7 +4,6 @@
 package media
 
 import (
-	"encoding/json"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -14,49 +13,50 @@ import (
 
 func getMediaData(mediaData types.MediaData) (types.MediaData, error) {
 	// On Linux, we'll use playerctl to get media information
-	cmd := exec.Command("playerctl", "metadata", "--format", "json", "--all-players")
+	cmd := exec.Command("playerctl", "metadata", "--format", "{{title}}\t{{artist}}\t{{album}}\t{{mpris:length}}\t{{position}}\t{{status}}\t{{playerName}}\t{{volume}}\t{{shuffle}}\t{{loopStatus}}", "--all-players")
 	output, err := cmd.Output()
 	if err == nil {
-		var metadata struct {
-			Title       string  `json:"title"`
-			Artist      string  `json:"artist"`
-			Album       string  `json:"album"`
-			Duration    string  `json:"duration"`
-			Position    string  `json:"position"`
-			Status      string  `json:"status"`
-			PlayerName  string  `json:"playerName"`
-			Volume      float64 `json:"volume"`
-			Shuffle     string  `json:"shuffle"`
-			LoopStatus  string  `json:"loopStatus"`
-		}
-		if err := json.Unmarshal(output, &metadata); err == nil {
-			mediaData.Title = &metadata.Title
-			mediaData.Artist = &metadata.Artist
-			mediaData.AlbumTitle = &metadata.Album
-			mediaData.Status = &metadata.Status
-			mediaData.Type = &metadata.PlayerName
+		fields := strings.SplitN(strings.TrimSpace(string(output)), "\t", 10)
+		if len(fields) >= 10 {
+			title := fields[0]
+			artist := fields[1]
+			album := fields[2]
+			durationStr := fields[3]
+			positionStr := fields[4]
+			status := fields[5]
+			playerName := fields[6]
+			shuffle := fields[8]
+			loopStatus := fields[9]
 
-			// Convert duration and position to float64
-			if duration, err := strconv.ParseFloat(metadata.Duration, 64); err == nil {
-				mediaData.Duration = &duration
+			mediaData.Title = &title
+			mediaData.Artist = &artist
+			mediaData.AlbumTitle = &album
+			mediaData.Status = &status
+			mediaData.Type = &playerName
+
+			// Convert duration and position to float64 (duration is in microseconds)
+			if duration, err := strconv.ParseFloat(durationStr, 64); err == nil {
+				dur := duration / 1e6 // convert microseconds to seconds
+				mediaData.Duration = &dur
 			}
-			if position, err := strconv.ParseFloat(metadata.Position, 64); err == nil {
-				mediaData.Position = &position
+			if position, err := strconv.ParseFloat(positionStr, 64); err == nil {
+				pos := position / 1e6 // convert microseconds to seconds
+				mediaData.Position = &pos
 			}
 
 			// Set control states based on status
-			isPlaying := strings.ToLower(metadata.Status) == "playing"
+			isPlaying := strings.ToLower(status) == "playing"
 			mediaData.IsPlayEnabled = &[]bool{!isPlaying}[0]
 			mediaData.IsPauseEnabled = &[]bool{isPlaying}[0]
 			mediaData.IsStopEnabled = &[]bool{true}[0]
 
 			// Set shuffle and repeat states
-			if metadata.Shuffle != "" {
-				isShuffle := strings.ToLower(metadata.Shuffle) == "on"
+			if shuffle != "" {
+				isShuffle := strings.ToLower(shuffle) == "on"
 				mediaData.Shuffle = &isShuffle
 			}
-			if metadata.LoopStatus != "" {
-				mediaData.Repeat = &metadata.LoopStatus
+			if loopStatus != "" {
+				mediaData.Repeat = &loopStatus
 			}
 		}
 	}

--- a/data/module/media/media_linux.go
+++ b/data/module/media/media_linux.go
@@ -4,6 +4,7 @@
 package media
 
 import (
+	"encoding/json"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -13,50 +14,51 @@ import (
 
 func getMediaData(mediaData types.MediaData) (types.MediaData, error) {
 	// On Linux, we'll use playerctl to get media information
-	cmd := exec.Command("playerctl", "metadata", "--format", "{{title}}\t{{artist}}\t{{album}}\t{{mpris:length}}\t{{position}}\t{{status}}\t{{playerName}}\t{{volume}}\t{{shuffle}}\t{{loopStatus}}", "--all-players")
+	cmd := exec.Command("playerctl", "metadata", "--format", `{"title":"{{title}}","artist":"{{artist}}","album":"{{album}}","duration":"{{mpris:length}}","position":"{{position}}","status":"{{status}}","playerName":"{{playerName}}","volume":"{{volume}}","shuffle":"{{shuffle}}","loopStatus":"{{loopStatus}}"}`, "--all-players")
 	output, err := cmd.Output()
 	if err == nil {
-		fields := strings.SplitN(strings.TrimSpace(string(output)), "\t", 10)
-		if len(fields) >= 10 {
-			title := fields[0]
-			artist := fields[1]
-			album := fields[2]
-			durationStr := fields[3]
-			positionStr := fields[4]
-			status := fields[5]
-			playerName := fields[6]
-			shuffle := fields[8]
-			loopStatus := fields[9]
-
-			mediaData.Title = &title
-			mediaData.Artist = &artist
-			mediaData.AlbumTitle = &album
-			mediaData.Status = &status
-			mediaData.Type = &playerName
+		var metadata struct {
+			Title       string  `json:"title"`
+			Artist      string  `json:"artist"`
+			Album       string  `json:"album"`
+			Duration    string  `json:"duration"`
+			Position    string  `json:"position"`
+			Status      string  `json:"status"`
+			PlayerName  string  `json:"playerName"`
+			Volume      float64 `json:"volume"`
+			Shuffle     string  `json:"shuffle"`
+			LoopStatus  string  `json:"loopStatus"`
+		}
+		if err := json.Unmarshal(output, &metadata); err == nil {
+			mediaData.Title = &metadata.Title
+			mediaData.Artist = &metadata.Artist
+			mediaData.AlbumTitle = &metadata.Album
+			mediaData.Status = &metadata.Status
+			mediaData.Type = &metadata.PlayerName
 
 			// Convert duration and position to float64 (duration is in microseconds)
-			if duration, err := strconv.ParseFloat(durationStr, 64); err == nil {
+			if duration, err := strconv.ParseFloat(metadata.Duration, 64); err == nil {
 				dur := duration / 1e6 // convert microseconds to seconds
 				mediaData.Duration = &dur
 			}
-			if position, err := strconv.ParseFloat(positionStr, 64); err == nil {
+			if position, err := strconv.ParseFloat(metadata.Position, 64); err == nil {
 				pos := position / 1e6 // convert microseconds to seconds
 				mediaData.Position = &pos
 			}
 
 			// Set control states based on status
-			isPlaying := strings.ToLower(status) == "playing"
+			isPlaying := strings.ToLower(metadata.Status) == "playing"
 			mediaData.IsPlayEnabled = &[]bool{!isPlaying}[0]
 			mediaData.IsPauseEnabled = &[]bool{isPlaying}[0]
 			mediaData.IsStopEnabled = &[]bool{true}[0]
 
 			// Set shuffle and repeat states
-			if shuffle != "" {
-				isShuffle := strings.ToLower(shuffle) == "on"
+			if metadata.Shuffle != "" {
+				isShuffle := strings.ToLower(metadata.Shuffle) == "on"
 				mediaData.Shuffle = &isShuffle
 			}
-			if loopStatus != "" {
-				mediaData.Repeat = &loopStatus
+			if metadata.LoopStatus != "" {
+				mediaData.Repeat = &metadata.LoopStatus
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #3471


Revised command:

```bash
playerctl metadata --format '{"title":"{{title}}","artist":"{{artist}}","album":"{{album}}","duration":"{{mpris:length}}","position":"{{position}}","status":"{{status}}","playerName":"{{playerName}}","volume":"{{volume}}","shuffle":"{{shuffle}}","loopStatus":"{{loopStatus}}"}' --all-players
```