### PR TITLE
Media windows from timmo001/dotnet-now-playing

### DIFF
--- a/.github/workflows/build-and-package-application.yml
+++ b/.github/workflows/build-and-package-application.yml
@@ -107,6 +107,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Download NowPlaying helper
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.scripts/windows/download-now-playing.ps1
+
       - name: Setup Go
         uses: ./.github/actions/setup-go
 
@@ -122,12 +128,6 @@ jobs:
 
       - name: Install NSIS
         run: choco install nsis -y --no-progress --limit-output
-
-      - name: Download NowPlaying helper
-        shell: pwsh
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: ./.scripts/windows/download-now-playing.ps1
 
       - name: Get version
         id: get_version

--- a/.github/workflows/build-and-package-application.yml
+++ b/.github/workflows/build-and-package-application.yml
@@ -120,6 +120,12 @@ jobs:
       - name: Install NSIS
         run: choco install nsis -y --no-progress --limit-output
 
+      - name: Download NowPlaying helper
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./.scripts/windows/download-now-playing.ps1
+
       - name: Get version
         id: get_version
         shell: bash

--- a/.github/workflows/build-and-package-application.yml
+++ b/.github/workflows/build-and-package-application.yml
@@ -126,7 +126,8 @@ jobs:
       - name: Download NowPlaying helper
         shell: pwsh
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ""
+          GITHUB_TOKEN: ""
         run: ./.scripts/windows/download-now-playing.ps1
 
       - name: Get version

--- a/.github/workflows/build-and-package-application.yml
+++ b/.github/workflows/build-and-package-application.yml
@@ -21,9 +21,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_type == 'tag' && format('tag-{0}', github.ref_name) || github.ref }}
   cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
-permissions:
-  contents: read
-
 jobs:
   build-linux:
     name: Build and package (Linux)
@@ -110,7 +107,7 @@ jobs:
       - name: Download NowPlaying helper
         shell: pwsh
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: ./.scripts/windows/download-now-playing.ps1
 
       - name: Setup Go

--- a/.github/workflows/build-and-package-application.yml
+++ b/.github/workflows/build-and-package-application.yml
@@ -21,6 +21,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_type == 'tag' && format('tag-{0}', github.ref_name) || github.ref }}
   cancel-in-progress: ${{ github.ref_type != 'tag' }}
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     name: Build and package (Linux)

--- a/.github/workflows/build-and-package-application.yml
+++ b/.github/workflows/build-and-package-application.yml
@@ -126,8 +126,7 @@ jobs:
       - name: Download NowPlaying helper
         shell: pwsh
         env:
-          GH_TOKEN: ""
-          GITHUB_TOKEN: ""
+          GH_TOKEN: ${{ github.token }}
         run: ./.scripts/windows/download-now-playing.ps1
 
       - name: Get version

--- a/.github/workflows/lint-package-config.yml
+++ b/.github/workflows/lint-package-config.yml
@@ -101,9 +101,15 @@ jobs:
       - name: Create dummy files for validation
         run: |
           # Create dist directory for NSIS output
+          New-Item -ItemType Directory -Path "now-playing" -Force
+
+          # Create an empty file to serve as the dummy executable for the now-playing helper
+          New-Item -ItemType File -Path "now-playing/NowPlaying.exe" -Force
+
+          # Create dist directory for NSIS output
           New-Item -ItemType Directory -Path "dist" -Force
 
-          # Create an empty file to serve as the dummy executable
+          # Create an empty file to serve as the dummy executable for the main application
           New-Item -ItemType File -Path "dist/system-bridge.exe" -Force
 
           # Create dist directory for NSIS output

--- a/.github/workflows/lint-package-config.yml
+++ b/.github/workflows/lint-package-config.yml
@@ -101,10 +101,10 @@ jobs:
       - name: Create dummy files for validation
         run: |
           # Create dist directory for NSIS output
-          New-Item -ItemType Directory -Path "now-playing" -Force
+          New-Item -ItemType Directory -Path ".scripts/windows/now-playing" -Force
 
           # Create an empty file to serve as the dummy executable for the now-playing helper
-          New-Item -ItemType File -Path "now-playing/NowPlaying.exe" -Force
+          New-Item -ItemType File -Path ".scripts/windows/now-playing/NowPlaying.exe" -Force
 
           # Create dist directory for NSIS output
           New-Item -ItemType Directory -Path "dist" -Force

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ installer.nsi
 
 # Build
 build/
+
+# External helper (downloaded at build time)
+.scripts/windows/now-playing/
+now-playing/

--- a/.scripts/windows/create-installer.ps1
+++ b/.scripts/windows/create-installer.ps1
@@ -56,6 +56,15 @@ if (-not (Test-Path $iconPath)) {
     exit 1
 }
 
+# Ensure NowPlaying helper exists (download step should have run earlier)
+$nowPlayingDir = ".\now-playing"
+if (-not (Test-Path $nowPlayingDir)) {
+    $nowPlayingDir = ".\.scripts\windows\now-playing"
+}
+if (-not (Test-Path (Join-Path $nowPlayingDir "NowPlaying.exe"))) {
+    Write-Warning "NowPlaying helper not found; installer will be built without it."
+}
+
 # Get the script directory
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 

--- a/.scripts/windows/download-now-playing.ps1
+++ b/.scripts/windows/download-now-playing.ps1
@@ -1,40 +1,20 @@
-param(
-    [string]$Repo = 'timmo001/dotnet-now-playing'
-)
-
 $ErrorActionPreference = 'Stop'
-
-function Test-GhAvailable {
-    return [bool](Get-Command gh -ErrorAction SilentlyContinue)
-}
-
-function Download-With-Gh {
-    param(
-        [string]$Repository,
-        [string]$Destination
-    )
-    $temp = Join-Path $env:TEMP ("npdl_" + [guid]::NewGuid())
-    New-Item -ItemType Directory -Path $temp -Force | Out-Null
-    try {
-        # Download the latest matching zip asset
-        gh release download -R $Repository -p '*.zip' -D $temp --clobber | Out-Null
-        $zip = Get-ChildItem -Path $temp -Filter *.zip | Select-Object -First 1
-        if (-not $zip) { throw 'No zip asset found' }
-
-        if (Test-Path $Destination) { Remove-Item -Recurse -Force $Destination }
-        New-Item -ItemType Directory -Path $Destination -Force | Out-Null
-
-        Expand-Archive -Path $zip.FullName -DestinationPath $Destination -Force
-    } finally {
-        if (Test-Path $temp) { Remove-Item -Recurse -Force $temp }
-    }
-}
 
 $outDir = Join-Path (Get-Location) '.scripts/windows/now-playing'
 
+$temp = Join-Path $env:TEMP ("npdl_" + [guid]::NewGuid())
+New-Item -ItemType Directory -Path $temp -Force | Out-Null
 try {
-    Download-With-Gh -Repository $Repo -Destination $outDir
-} catch {
-    Write-Error "Failed to download NowPlaying: $_"
-    exit 1
+    gh release download -R timmo001/dotnet-now-playing -p '*.zip' -D $temp --clobber | Out-Null
+    $zip = Get-ChildItem -Path $temp -Filter *.zip | Select-Object -First 1
+    if (-not $zip) { throw 'No zip asset found' }
+
+    if (Test-Path $outDir) { Remove-Item -Recurse -Force $outDir }
+    New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+
+    Expand-Archive -Path $zip.FullName -DestinationPath $outDir -Force
+    Write-Output "NowPlaying helper downloaded to $outDir"
+}
+finally {
+    if (Test-Path $temp) { Remove-Item -Recurse -Force $temp }
 }

--- a/.scripts/windows/download-now-playing.ps1
+++ b/.scripts/windows/download-now-playing.ps1
@@ -1,60 +1,40 @@
+param(
+    [string]$Repo = 'timmo001/dotnet-now-playing'
+)
+
 $ErrorActionPreference = 'Stop'
 
-function Get-AuthHeaders {
-    $headers = @{ 'User-Agent' = 'system-bridge' }
-    if ($env:GITHUB_TOKEN) {
-        $headers['Authorization'] = "Bearer $($env:GITHUB_TOKEN)"
-    }
-    return $headers
+function Test-GhAvailable {
+    return [bool](Get-Command gh -ErrorAction SilentlyContinue)
 }
 
-function Get-LatestReleaseAssetUrl {
-    $headers = Get-AuthHeaders
-    $release = $null
+function Download-With-Gh {
+    param(
+        [string]$Repository,
+        [string]$Destination
+    )
+    $temp = Join-Path $env:TEMP ("npdl_" + [guid]::NewGuid())
+    New-Item -ItemType Directory -Path $temp -Force | Out-Null
     try {
-        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/timmo001/dotnet-now-playing/releases/latest" -Headers $headers -ErrorAction Stop
-    } catch {
-        # Fallback for when latest is not available (e.g., private repos without auth or no latest)
-        try {
-            $list = Invoke-RestMethod -Uri "https://api.github.com/repos/timmo001/dotnet-now-playing/releases" -Headers $headers -ErrorAction Stop
-            $release = $list | Where-Object { -not $_.draft -and -not $_.prerelease } | Select-Object -First 1
-        } catch {
-            throw "Failed to query releases for timmo001/dotnet-now-playing: $_"
-        }
-    }
+        # Download the latest matching zip asset
+        gh release download -R $Repository -p '*.zip' -D $temp --clobber | Out-Null
+        $zip = Get-ChildItem -Path $temp -Filter *.zip | Select-Object -First 1
+        if (-not $zip) { throw 'No zip asset found' }
 
-    if (-not $release) { throw "No release found for timmo001/dotnet-now-playing" }
+        if (Test-Path $Destination) { Remove-Item -Recurse -Force $Destination }
+        New-Item -ItemType Directory -Path $Destination -Force | Out-Null
 
-    $asset = $release.assets | Where-Object { $_.name -match '(?i)^nowplaying-.*\.zip$' } | Select-Object -First 1
-    if (-not $asset) { $asset = $release.assets | Where-Object { $_.name -match '(?i)\.zip$' } | Select-Object -First 1 }
-    if (-not $asset) { throw "Could not find suitable zip asset in timmo001/dotnet-now-playing release $($release.tag_name)" }
-    return $asset.browser_download_url
-}
-
-function Ensure-NowPlaying {
-    $outDirPrimary = Join-Path (Get-Location) 'now-playing'
-    $outDirFallback = Join-Path (Get-Location) '.scripts/windows/now-playing'
-
-    $targetDir = $outDirPrimary
-    if (-not (Test-Path $targetDir)) {
-        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
-    }
-
-    try {
-        $url = Get-LatestReleaseAssetUrl
-        $zipPath = Join-Path $env:TEMP 'nowplaying.zip'
-        $headers = Get-AuthHeaders
-        Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing -Headers $headers
-        # Extract preserving folder structure
-        if (Test-Path $targetDir) { Remove-Item -Recurse -Force $targetDir }
-        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
-        Add-Type -AssemblyName System.IO.Compression.FileSystem
-        [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $targetDir)
-        Remove-Item $zipPath -Force
-    } catch {
-        Write-Warning "Failed to download NowPlaying: $_"
-        if (-not (Test-Path $outDirFallback)) { New-Item -ItemType Directory -Path $outDirFallback -Force | Out-Null }
+        Expand-Archive -Path $zip.FullName -DestinationPath $Destination -Force
+    } finally {
+        if (Test-Path $temp) { Remove-Item -Recurse -Force $temp }
     }
 }
 
-Ensure-NowPlaying
+$outDir = Join-Path (Get-Location) '.scripts/windows/now-playing'
+
+try {
+    Download-With-Gh -Repository $Repo -Destination $outDir
+} catch {
+    Write-Error "Failed to download NowPlaying: $_"
+    exit 1
+}

--- a/.scripts/windows/download-now-playing.ps1
+++ b/.scripts/windows/download-now-playing.ps1
@@ -26,7 +26,7 @@ function Get-LatestReleaseAssetUrl {
             $list = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/releases" -Headers $headers -ErrorAction Stop
             $release = $list | Where-Object { -not $_.draft -and -not $_.prerelease } | Select-Object -First 1
         } catch {
-            throw "Failed to query releases for $Repository: $_"
+            throw "Failed to query releases for ${Repository}: $_"
         }
     }
 

--- a/.scripts/windows/download-now-playing.ps1
+++ b/.scripts/windows/download-now-playing.ps1
@@ -1,0 +1,67 @@
+param(
+    [string]$Repo = "timmo001/dotnet-now-playing"
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Get-AuthHeaders {
+    $headers = @{ 'User-Agent' = 'system-bridge' }
+    if ($env:GITHUB_TOKEN) {
+        $headers['Authorization'] = "Bearer $($env:GITHUB_TOKEN)"
+    }
+    return $headers
+}
+
+function Get-LatestReleaseAssetUrl {
+    param(
+        [string]$Repository
+    )
+    $headers = Get-AuthHeaders
+    $release = $null
+    try {
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/releases/latest" -Headers $headers -ErrorAction Stop
+    } catch {
+        # Fallback for when latest is not available (e.g., private repos without auth or no latest)
+        try {
+            $list = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/releases" -Headers $headers -ErrorAction Stop
+            $release = $list | Where-Object { -not $_.draft -and -not $_.prerelease } | Select-Object -First 1
+        } catch {
+            throw "Failed to query releases for $Repository: $_"
+        }
+    }
+
+    if (-not $release) { throw "No release found for $Repository" }
+
+    $asset = $release.assets | Where-Object { $_.name -match '(?i)^nowplaying-.*\.zip$' } | Select-Object -First 1
+    if (-not $asset) { $asset = $release.assets | Where-Object { $_.name -match '(?i)\.zip$' } | Select-Object -First 1 }
+    if (-not $asset) { throw "Could not find suitable zip asset in $Repository release $($release.tag_name)" }
+    return $asset.browser_download_url
+}
+
+function Ensure-NowPlaying {
+    $outDirPrimary = Join-Path (Get-Location) 'now-playing'
+    $outDirFallback = Join-Path (Get-Location) '.scripts/windows/now-playing'
+
+    $targetDir = $outDirPrimary
+    if (-not (Test-Path $targetDir)) {
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    }
+
+    try {
+        $url = Get-LatestReleaseAssetUrl -Repository $Repo
+        $zipPath = Join-Path $env:TEMP 'nowplaying.zip'
+        $headers = Get-AuthHeaders
+        Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing -Headers $headers
+        # Extract preserving folder structure
+        if (Test-Path $targetDir) { Remove-Item -Recurse -Force $targetDir }
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [System.IO.Compression.ZipFile]::ExtractToDirectory($zipPath, $targetDir)
+        Remove-Item $zipPath -Force
+    } catch {
+        Write-Warning "Failed to download NowPlaying: $_"
+        if (-not (Test-Path $outDirFallback)) { New-Item -ItemType Directory -Path $outDirFallback -Force | Out-Null }
+    }
+}
+
+Ensure-NowPlaying

--- a/.scripts/windows/download-now-playing.ps1
+++ b/.scripts/windows/download-now-playing.ps1
@@ -1,7 +1,3 @@
-param(
-    [string]$Repo = "timmo001/dotnet-now-playing"
-)
-
 $ErrorActionPreference = 'Stop'
 
 function Get-AuthHeaders {
@@ -13,28 +9,25 @@ function Get-AuthHeaders {
 }
 
 function Get-LatestReleaseAssetUrl {
-    param(
-        [string]$Repository
-    )
     $headers = Get-AuthHeaders
     $release = $null
     try {
-        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/releases/latest" -Headers $headers -ErrorAction Stop
+        $release = Invoke-RestMethod -Uri "https://api.github.com/repos/timmo001/dotnet-now-playing/releases/latest" -Headers $headers -ErrorAction Stop
     } catch {
         # Fallback for when latest is not available (e.g., private repos without auth or no latest)
         try {
-            $list = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repository/releases" -Headers $headers -ErrorAction Stop
+            $list = Invoke-RestMethod -Uri "https://api.github.com/repos/timmo001/dotnet-now-playing/releases" -Headers $headers -ErrorAction Stop
             $release = $list | Where-Object { -not $_.draft -and -not $_.prerelease } | Select-Object -First 1
         } catch {
-            throw "Failed to query releases for ${Repository}: $_"
+            throw "Failed to query releases for timmo001/dotnet-now-playing: $_"
         }
     }
 
-    if (-not $release) { throw "No release found for $Repository" }
+    if (-not $release) { throw "No release found for timmo001/dotnet-now-playing" }
 
     $asset = $release.assets | Where-Object { $_.name -match '(?i)^nowplaying-.*\.zip$' } | Select-Object -First 1
     if (-not $asset) { $asset = $release.assets | Where-Object { $_.name -match '(?i)\.zip$' } | Select-Object -First 1 }
-    if (-not $asset) { throw "Could not find suitable zip asset in $Repository release $($release.tag_name)" }
+    if (-not $asset) { throw "Could not find suitable zip asset in timmo001/dotnet-now-playing release $($release.tag_name)" }
     return $asset.browser_download_url
 }
 
@@ -48,7 +41,7 @@ function Ensure-NowPlaying {
     }
 
     try {
-        $url = Get-LatestReleaseAssetUrl -Repository $Repo
+        $url = Get-LatestReleaseAssetUrl
         $zipPath = Join-Path $env:TEMP 'nowplaying.zip'
         $headers = Get-AuthHeaders
         Invoke-WebRequest -Uri $url -OutFile $zipPath -UseBasicParsing -Headers $headers

--- a/.scripts/windows/installer.nsi.template
+++ b/.scripts/windows/installer.nsi.template
@@ -69,11 +69,11 @@ Section "Install"
   File /oname=system-bridge.ico ".resources\system-bridge-dimmed.ico"
   
   ; Include NowPlaying helper if present
-  IfFileExists ".\\now-playing\\NowPlaying.exe" +3 0
+  IfFileExists ".\\now-playing\\NowPlaying.exe" 0 +3
     SetOutPath "$INSTDIR\now-playing"
     File ".\\now-playing\\*.*"
     Goto np_end
-  IfFileExists ".\\.scripts\\windows\\now-playing\\NowPlaying.exe" +3 0
+  IfFileExists ".\\.scripts\\windows\\now-playing\\NowPlaying.exe" 0 +3
     SetOutPath "$INSTDIR\now-playing"
     File ".\\.scripts\\windows\\now-playing\\*.*"
   np_end:

--- a/.scripts/windows/installer.nsi.template
+++ b/.scripts/windows/installer.nsi.template
@@ -67,6 +67,15 @@ Section "Install"
   SetOutPath "$INSTDIR"
   File "dist\system-bridge.exe"
   File /oname=system-bridge.ico ".resources\system-bridge-dimmed.ico"
+  
+  ; Include NowPlaying helper if present
+  SetOutPath "$INSTDIR\now-playing"
+  IfFileExists ".\\now-playing\\NowPlaying.exe" 0 +3
+    File ".\\now-playing\\*.*"
+    Goto np_end
+  IfFileExists ".\\.scripts\\windows\\now-playing\\NowPlaying.exe" 0 np_end
+    File ".\\.scripts\\windows\\now-playing\\*.*"
+  np_end:
 
   # Register uninstaller in Windows registry
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\System Bridge" "DisplayName" "System Bridge"

--- a/.scripts/windows/installer.nsi.template
+++ b/.scripts/windows/installer.nsi.template
@@ -72,7 +72,6 @@ Section "Install"
   IfFileExists ".\\.scripts\\windows\\now-playing\\NowPlaying.exe" 0 +3
     SetOutPath "$INSTDIR\now-playing"
     File ".\\.scripts\\windows\\now-playing\\*.*"
-  np_end:
 
   # Register uninstaller in Windows registry
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\System Bridge" "DisplayName" "System Bridge"

--- a/.scripts/windows/installer.nsi.template
+++ b/.scripts/windows/installer.nsi.template
@@ -69,11 +69,12 @@ Section "Install"
   File /oname=system-bridge.ico ".resources\system-bridge-dimmed.ico"
   
   ; Include NowPlaying helper if present
-  SetOutPath "$INSTDIR\now-playing"
-  IfFileExists ".\\now-playing\\NowPlaying.exe" 0 +3
+  IfFileExists ".\\now-playing\\NowPlaying.exe" +3 0
+    SetOutPath "$INSTDIR\now-playing"
     File ".\\now-playing\\*.*"
     Goto np_end
-  IfFileExists ".\\.scripts\\windows\\now-playing\\NowPlaying.exe" 0 np_end
+  IfFileExists ".\\.scripts\\windows\\now-playing\\NowPlaying.exe" +3 0
+    SetOutPath "$INSTDIR\now-playing"
     File ".\\.scripts\\windows\\now-playing\\*.*"
   np_end:
 

--- a/.scripts/windows/installer.nsi.template
+++ b/.scripts/windows/installer.nsi.template
@@ -69,10 +69,6 @@ Section "Install"
   File /oname=system-bridge.ico ".resources\system-bridge-dimmed.ico"
   
   ; Include NowPlaying helper if present
-  IfFileExists ".\\now-playing\\NowPlaying.exe" 0 +3
-    SetOutPath "$INSTDIR\now-playing"
-    File ".\\now-playing\\*.*"
-    Goto np_end
   IfFileExists ".\\.scripts\\windows\\now-playing\\NowPlaying.exe" 0 +3
     SetOutPath "$INSTDIR\now-playing"
     File ".\\.scripts\\windows\\now-playing\\*.*"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ifeq ($(OS),Windows_NT)
 	BUN_BUILD=set STATIC_EXPORT=true && bun run build
 	EXTRA_LDFLAGS=-H windowsgui
 	GEN_RC=powershell -ExecutionPolicy Bypass -File ./.scripts/windows/generate-rc.ps1
+	DL_NOW_PLAYING=powershell -ExecutionPolicy Bypass -File ./.scripts/windows/download-now-playing.ps1
 else
 	EXE=
 	RM=rm -f
@@ -18,6 +19,7 @@ endif
 
 build: clean build_web_client
 ifeq ($(OS),Windows_NT)
+	$(DL_NOW_PLAYING);
 	$(GEN_RC)
 	windres system-bridge.rc -O coff -o system-bridge.syso
 	go build -v -ldflags="$(EXTRA_LDFLAGS) -X 'github.com/timmo001/system-bridge/version.Version=5.0.0-dev+$(shell git rev-parse --short HEAD)'" -o "$(OUT)" .
@@ -40,8 +42,11 @@ create_deb: clean_dist
 create_rpm: clean_dist
 	VERSION=5.0.0-dev+$(shell git rev-parse --short HEAD) ./.scripts/linux/create-rpm.sh
 
-create_windows_installer: clean_dist
+create_windows_installer: clean_dist download_windows_now_playing
 	powershell -ExecutionPolicy Bypass -File ./.scripts/windows/create-installer.ps1 /Clean
+
+download_windows_now_playing:
+	powershell -ExecutionPolicy Bypass -File ./.scripts/windows/download-now-playing.ps1
 
 install: build
 	go install .

--- a/data/module/media/media_windows.go
+++ b/data/module/media/media_windows.go
@@ -4,10 +4,161 @@
 package media
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"log/slog"
+
 	"github.com/timmo001/system-bridge/types"
+	"github.com/timmo001/system-bridge/utils"
 )
 
+// locateNowPlayingExe attempts to find the NowPlaying.exe shipped with the Windows package
+// Search order:
+// 1. <exe_dir>\now-playing\NowPlaying.exe (installed build)
+// 2. .\now-playing\NowPlaying.exe (project root during development)
+// 3. .\.scripts\windows\now-playing\NowPlaying.exe (development fallback)
+func locateNowPlayingExe() (string, error) {
+    // 1) Installed path beside our executable
+    if exe, err := os.Executable(); err == nil {
+        base := filepath.Dir(exe)
+        candidate := filepath.Join(base, "now-playing", "NowPlaying.exe")
+        if stat, err := os.Stat(candidate); err == nil && !stat.IsDir() {
+            return candidate, nil
+        }
+    }
+
+    // 2) Project root path
+    if wd, err := os.Getwd(); err == nil {
+        candidate := filepath.Join(wd, "now-playing", "NowPlaying.exe")
+        if stat, err := os.Stat(candidate); err == nil && !stat.IsDir() {
+            return candidate, nil
+        }
+    }
+
+    // 3) Scripts path
+    if wd, err := os.Getwd(); err == nil {
+        candidate := filepath.Join(wd, ".scripts", "windows", "now-playing", "NowPlaying.exe")
+        if stat, err := os.Stat(candidate); err == nil && !stat.IsDir() {
+            return candidate, nil
+        }
+    }
+
+    return "", errors.New("NowPlaying.exe not found")
+}
+
 func getMediaData(mediaData types.MediaData) (types.MediaData, error) {
-  // TODO: Implement
-  return mediaData, nil
+    exePath, err := locateNowPlayingExe()
+    if err != nil {
+        // Fail quietly and keep defaults
+        slog.Error("NowPlaying.exe not found", "error", err)
+        return mediaData, nil
+    }
+
+    cmd := exec.Command(exePath)
+    utils.SetHideWindow(cmd)
+
+    var stdout bytes.Buffer
+    var stderr bytes.Buffer
+    cmd.Stdout = &stdout
+    cmd.Stderr = &stderr
+
+    if err := cmd.Run(); err != nil {
+        slog.Error("NowPlaying.exe failed", "error", err.Error(), "stderr", strings.TrimSpace(stderr.String()))
+        return mediaData, nil
+    }
+
+    output := strings.TrimSpace(stdout.String())
+    if output == "" {
+        return mediaData, nil
+    }
+
+    // Try to decode into expected structure first; fall back to generic map if needed
+    var metadata struct {
+        Title      string  `json:"Title"`
+        Artist     string  `json:"Artist"`
+        AlbumTitle string  `json:"AlbumTitle"`
+        Status     string  `json:"Status"`
+        Duration   float64 `json:"Duration"`
+        Position   float64 `json:"Position"`
+        PlayerName string  `json:"PlayerName"`
+        Shuffle    bool    `json:"Shuffle"`
+        RepeatMode string  `json:"RepeatMode"`
+    }
+    if err := json.Unmarshal([]byte(output), &metadata); err != nil {
+        // best-effort parse: try map[string]any to avoid fatal behavior
+        var generic map[string]any
+        if err2 := json.Unmarshal([]byte(output), &generic); err2 != nil {
+            slog.Error("NowPlaying.exe JSON parse error", "error", err.Error(), "raw_output", output)
+            return mediaData, nil
+        }
+        // extract common fields if present
+        if v, ok := generic["Title"].(string); ok {
+            metadata.Title = v
+        }
+        if v, ok := generic["Artist"].(string); ok {
+            metadata.Artist = v
+        }
+        if v, ok := generic["AlbumTitle"].(string); ok {
+            metadata.AlbumTitle = v
+        }
+        if v, ok := generic["Status"].(string); ok {
+            metadata.Status = v
+        }
+        if v, ok := generic["PlayerName"].(string); ok {
+            metadata.PlayerName = v
+        }
+        if v, ok := generic["Shuffle"].(bool); ok {
+            metadata.Shuffle = v
+        }
+        if v, ok := generic["RepeatMode"].(string); ok {
+            metadata.RepeatMode = v
+        }
+        if v, ok := generic["Duration"].(float64); ok {
+            metadata.Duration = v
+        }
+        if v, ok := generic["Position"].(float64); ok {
+            metadata.Position = v
+        }
+    }
+
+    mediaData.Title = &metadata.Title
+    mediaData.Artist = &metadata.Artist
+    mediaData.AlbumTitle = &metadata.AlbumTitle
+    mediaData.Status = &metadata.Status
+    mediaData.Type = &metadata.PlayerName
+    mediaData.Duration = &metadata.Duration
+    mediaData.Position = &metadata.Position
+    mediaData.Shuffle = &metadata.Shuffle
+
+    // Map repeat mode
+    repeatStatus := "none"
+    switch strings.ToLower(metadata.RepeatMode) {
+    case "track", "one":
+        repeatStatus = "one"
+    case "list", "all":
+        repeatStatus = "all"
+    }
+    mediaData.Repeat = &repeatStatus
+
+    // Controls
+    isPlaying := strings.EqualFold(metadata.Status, "playing")
+    isPaused := strings.EqualFold(metadata.Status, "paused")
+    isStopped := strings.EqualFold(metadata.Status, "stopped")
+
+    canPlay := isPaused || isStopped
+    canPause := isPlaying
+    canStop := isPlaying || isPaused
+
+    mediaData.IsPlayEnabled = &canPlay
+    mediaData.IsPauseEnabled = &canPause
+    mediaData.IsStopEnabled = &canStop
+
+    // Volume is not exposed by the helper; leave as nil to keep defaults
+    return mediaData, nil
 }

--- a/data/module/media/media_windows_test.go
+++ b/data/module/media/media_windows_test.go
@@ -1,0 +1,42 @@
+//go:build windows
+// +build windows
+
+package media
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMediaDataWindows(t *testing.T) {
+	// This test will run the actual PowerShell command.
+	// It's more of an integration test for the Windows media retrieval.
+	// Note: This test's success depends on media (like Spotify, a YouTube video, etc.)
+	// playing on the system when the test is run.
+
+	t.Log("Testing media data retrieval on Windows.")
+	t.Log("Please ensure some media is playing for a comprehensive test.")
+
+	// Initialize with some default data
+	initialData, err := GetMediaData()
+	assert.NoError(t, err, "GetMediaData should not produce an error even if no media is playing.")
+
+	// The result can be empty if nothing is playing, which is a valid scenario.
+	// So we'll just log the output for manual verification.
+	if initialData.Title != nil {
+		t.Logf("Successfully retrieved media data:")
+		t.Logf("  Title: %s", *initialData.Title)
+		if initialData.Artist != nil {
+			t.Logf("  Artist: %s", *initialData.Artist)
+		}
+		if initialData.Status != nil {
+			t.Logf("  Status: %s", *initialData.Status)
+		}
+	} else {
+		t.Log("No active media session found, which is a valid outcome.")
+	}
+
+	// We can assert that the timestamp is recent.
+	assert.NotNil(t, initialData.UpdatedAt, "UpdatedAt should always be set.")
+}


### PR DESCRIPTION
This pull request adds robust support for integrating the NowPlaying helper on Windows, enabling the application to retrieve and expose current media playback information. The changes automate downloading, packaging, and runtime discovery of the NowPlaying executable, and update the Windows media module to use this helper. Additionally, a new test ensures the integration works as expected.

**Windows NowPlaying Integration:**

* Added a new script (`.scripts/windows/download-now-playing.ps1`) to automatically download the latest NowPlaying helper release from GitHub, with support for GitHub authentication and fallback logic.
* Updated the build and packaging process (`Makefile`, `.github/workflows/build-and-package-application.yml`) to invoke the download script and include the NowPlaying helper in the Windows installer if present. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R10) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R22) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L43-R50) [[4]](diffhunk://#diff-6ac686765dfaef44d77dca571fd40797cb0dfdaf7823f00e0f6a8bc1601457ceR123-R128) [[5]](diffhunk://#diff-67bb7f799158457cbbbebc33a740b82aa5313b1f48383af844fe748cb6fedd3eR71-R79) [[6]](diffhunk://#diff-181fb53934c1c6cfeafb63694ea13fa7cb4264725522622dc10386a75021a123R59-R67)

**Media Module Enhancement:**

* Refactored `media_windows.go` to locate and invoke the NowPlaying helper at runtime, parse its JSON output, and populate the application's media data structure accordingly. This includes robust error handling and fallback for missing or malformed data.

**Testing:**

* Added a Windows-specific integration test (`media_windows_test.go`) to verify that media data retrieval works and gracefully handles scenarios where no media is playing.