### PR TITLE
Initialize gpuList array on Linux

### DIFF
--- a/data/module/gpus/gpus_linux.go
+++ b/data/module/gpus/gpus_linux.go
@@ -13,7 +13,7 @@ import (
 )
 
 func getGPUs() ([]types.GPU, error) {
-	var gpuList []types.GPU
+	gpuList := make([]types.GPU, 0)
 
 	// Try to get NVIDIA GPU info first
 	cmd := exec.Command("nvidia-smi", "--query-gpu=gpu_name,memory.total,memory.used,memory.free,utilization.gpu,clocks.current.graphics,clocks.current.memory,power.draw,temperature.gpu", "--format=csv,noheader,nounits")


### PR DESCRIPTION
I have a few headless systems that don't have GPUs. I couldn't connect to them with Home Assistant, and after investigating, saw that the GPU module was returning null rather than an empty array. Not sure if this is the expected behavior, but something in the bridge connector didn't like it, and it caused the sync to timeout. Initializing the array seems to be all that was needed to get these headless systems working with HASS.