### PR TITLE
Set notification title for linux

### DIFF
--- a/utils/handlers/notification/notification_linux.go
+++ b/utils/handlers/notification/notification_linux.go
@@ -14,10 +14,6 @@ func send(data NotificationData) error {
 		"--urgency=normal",
 	}
 
-	if data.Title != "" {
-		args = append(args, "--title="+data.Title)
-	}
-
 	if data.Icon != "" {
 		args = append(args, "--icon="+data.Icon)
 	}
@@ -26,8 +22,15 @@ func send(data NotificationData) error {
 		args = append(args, "--expire-time="+strconv.Itoa(data.Duration))
 	}
 
+	
+	if data.Title != "" {
+		args = append(args, data.Title)
+	} else {
+		args = append(args, "Notification")
+	}
+		
 	args = append(args, data.Message)
-
+	
 	cmd := exec.Command("notify-send", args...)
 	return cmd.Run()
 }


### PR DESCRIPTION
Sending notifications is currently broken due because the title isn't set with an option, instead it's just another argument for the notification and needs to be set to ensure consistent styles for the notifications.