### PR TITLE
Add conflicts for debug package

### DIFF
--- a/.scripts/linux/PKGBUILD
+++ b/.scripts/linux/PKGBUILD
@@ -7,7 +7,7 @@ pkgver=${ARCH_PKGVER}
 pkgrel=1
 pkgdesc="A bridge for your systems"
 source=('system-bridge' 'system-bridge.desktop' 'system-bridge.svg' 'system-bridge-16.png' 'system-bridge-32.png' 'system-bridge-48.png' 'system-bridge-128.png' 'system-bridge-256.png' 'system-bridge-512.png' 'LICENSE')
-conflicts=('system-bridge-git')
+conflicts=('system-bridge-git' 'system-bridge-git-debug')
 
 arch=('x86_64')
 url="https://github.com/timmo001/system-bridge"

--- a/.scripts/linux/PKGBUILD.dev
+++ b/.scripts/linux/PKGBUILD.dev
@@ -10,7 +10,7 @@ pkgdesc="A bridge for your systems (git version)"
 makedepends=('git' 'go' 'pnpm')
 source=("$pkgname::git+https://github.com/timmo001/system-bridge.git")
 md5sums=('SKIP')
-conflicts=('system-bridge')
+conflicts=('system-bridge' 'system-bridge-debug')
 
 arch=('x86_64')
 url="https://github.com/timmo001/system-bridge"

--- a/.scripts/linux/PKGBUILD.release
+++ b/.scripts/linux/PKGBUILD.release
@@ -11,7 +11,7 @@ pkgdesc="A bridge for your systems"
 makedepends=('git' 'go' 'pnpm')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/timmo001/system-bridge/archive/refs/tags/TAGVER_PLACEHOLDER.tar.gz")
 sha256sums=('SKIP')
-conflicts=('system-bridge-git')
+conflicts=('system-bridge-git' 'system-bridge-git-debug')
 
 arch=('x86_64')
 url="https://github.com/timmo001/system-bridge"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates Arch packaging to prevent co-installation with debug variants.
> 
> - In `PKGBUILD` and `PKGBUILD.release`, add `conflicts=('system-bridge-git' 'system-bridge-git-debug')`
> - In `PKGBUILD.dev`, add `conflicts=('system-bridge' 'system-bridge-debug')`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80b3bc9003e55f93bdb24b32f4ae6b24c74292bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->