### PR TITLE
Add system-bridge-git-debug to conflicts

### DIFF
--- a/.scripts/linux/PKGBUILD.dev
+++ b/.scripts/linux/PKGBUILD.dev
@@ -10,7 +10,7 @@ pkgdesc="A bridge for your systems (git version)"
 makedepends=('git' 'go' 'pnpm')
 source=("$pkgname::git+https://github.com/timmo001/system-bridge.git")
 md5sums=('SKIP')
-conflicts=('system-bridge' 'system-bridge-debug')
+conflicts=('system-bridge' 'system-bridge-debug' 'system-bridge-git-debug')
 
 arch=('x86_64')
 url="https://github.com/timmo001/system-bridge"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates AUR packaging to avoid conflicting installations.
> 
> - In `PKGBUILD.dev`, adds `system-bridge-git-debug` to `conflicts` alongside existing `system-bridge` and `system-bridge-debug`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eca01a28e11c3f0d66bf2452bcc2d5113d3816b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->