### PR TITLE
Add copyable id to commands web client settings

### DIFF
--- a/web-client/src/pages/settings-commands.ts
+++ b/web-client/src/pages/settings-commands.ts
@@ -300,6 +300,18 @@ export class PageSettingsCommands extends PageElement {
     );
   };
 
+  private handleCopyId = async (e: Event): Promise<void> => {
+    const button = e.currentTarget as HTMLElement;
+    const id = button.getAttribute("data-id");
+    if (!id) return;
+
+    try {
+      await navigator.clipboard.writeText(id);
+    } catch (error) {
+      console.error("Failed to copy ID to clipboard:", error);
+    }
+  };
+
   private saveSettingsWithCommands(
     commands: SettingsCommandDefinition[],
   ): void {
@@ -375,6 +387,19 @@ export class PageSettingsCommands extends PageElement {
             <div class="font-medium">${cmd.name}</div>
             <div class="text-sm text-muted-foreground break-all">
               ${cmd.command}
+            </div>
+            <div class="flex items-center gap-2 text-xs text-muted-foreground">
+              <span><span class="select-none">ID: </span>${cmd.id}</span>
+              <ui-button
+                variant="ghost"
+                size="icon"
+                data-id=${cmd.id}
+                @click=${this.handleCopyId}
+                title="Copy ID"
+                class="h-5 w-5"
+              >
+                <ui-icon name="Copy" size="12"></ui-icon>
+              </ui-button>
             </div>
             ${cmd.workingDir
               ? html`


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds lightweight ID visibility and copy UX to aid command reference and integration.
> 
> - In `settings-commands.ts`, renders each command's `id` with a small "Copy" icon button
> - Implements `handleCopyId` using `navigator.clipboard.writeText` and wires it to the new button
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e644f097f0eac959219fa64462a97a9fc3c4af2b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->