### PR TITLE
Various linux related fixes

### DIFF
--- a/.scripts/linux/dev.timmo.system-bridge.yml
+++ b/.scripts/linux/dev.timmo.system-bridge.yml
@@ -9,6 +9,7 @@ finish-args:
   - --share=ipc
   - --socket=x11
   - --socket=wayland
+  - --socket=pulseaudio
   - --device=dri
   - --filesystem=host
   - --talk-name=org.freedesktop.Notifications

--- a/.scripts/linux/system-bridge.desktop
+++ b/.scripts/linux/system-bridge.desktop
@@ -5,4 +5,7 @@ Exec=system-bridge backend --open-web-client
 Icon=system-bridge
 Type=Application
 Categories=Utility;
+Terminal=false
+StartupNotify=false
+Keywords=system;bridge;monitor;
 X-GNOME-Autostart-enabled=true

--- a/.scripts/linux/system-bridge.service
+++ b/.scripts/linux/system-bridge.service
@@ -12,4 +12,4 @@ StandardError=syslog
 SyslogIdentifier=system-bridge
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target

--- a/data/playerctl_linux.go
+++ b/data/playerctl_linux.go
@@ -38,6 +38,8 @@ func StartPlayerctlListener(dataStore *DataStore) {
 			}
 		}
 
+		_ = cmd.Wait()
+
 		if err := scanner.Err(); err != nil {
 			slog.Info("playerctl listener stopped", "error", err)
 		}

--- a/utils/handlers/filesystem/filesystem_linux.go
+++ b/utils/handlers/filesystem/filesystem_linux.go
@@ -121,5 +121,5 @@ func getFileInfo(path string) (*FileInfo, error) {
 
 func openFile(path string) error {
 	cmd := exec.Command("xdg-open", path)
-	return cmd.Run()
+	return cmd.Start()
 }

--- a/utils/handlers/media/media_linux.go
+++ b/utils/handlers/media/media_linux.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package media
 
 import (
@@ -15,12 +17,14 @@ func control(action MediaAction) error {
 		cmd = exec.Command("playerctl", "next")
 	case MediaActionPrevious:
 		cmd = exec.Command("playerctl", "previous")
+	case MediaActionStop:
+		cmd = exec.Command("playerctl", "stop")
 	case MediaActionVolumeUp:
-		cmd = exec.Command("playerctl", "volume-up")
+		cmd = exec.Command("playerctl", "volume", "0.05+")
 	case MediaActionVolumeDown:
-		cmd = exec.Command("playerctl", "volume-down")
+		cmd = exec.Command("playerctl", "volume", "0.05-")
 	case MediaActionMute:
-		cmd = exec.Command("playerctl", "mute")
+		cmd = exec.Command("playerctl", "volume", "0")
 	default:
 		return fmt.Errorf("unsupported media action: %s", action)
 	}

--- a/utils/handlers/power/power_linux.go
+++ b/utils/handlers/power/power_linux.go
@@ -3,6 +3,7 @@
 package power
 
 import (
+	"os"
 	"os/exec"
 )
 
@@ -32,6 +33,10 @@ func lock() error {
 }
 
 func logout() error {
-	cmd := exec.Command("loginctl", "terminate-session", "$XDG_SESSION_ID")
+	sessionID := os.Getenv("XDG_SESSION_ID")
+	if sessionID == "" {
+		sessionID = "self"
+	}
+	cmd := exec.Command("loginctl", "terminate-session", sessionID)
 	return cmd.Run()
 }


### PR DESCRIPTION
- fix(linux): correct display mode selection, DotClock units, and isPrimary detection
- fix(linux): resolve XDG_SESSION_ID env var in logout instead of passing literal string
- fix(linux): add build tag, stop action, and correct playerctl volume/mute commands
- fix(linux): compute GPU memory load from usage and fix lspci VGA name parsing
- fix(linux): reap playerctl child process to prevent zombie on exit
- fix(linux): use cmd.Start for xdg-open to avoid blocking until app exits
- fix(linux): add pulseaudio socket to Flatpak, fix systemd target, and add desktop entry fields