### PR TITLE
Shared backend auth validator

### DIFF
--- a/backend/auth/auth.go
+++ b/backend/auth/auth.go
@@ -1,0 +1,70 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+)
+
+type Validator struct {
+	token string
+}
+
+type RequestTokenOptions struct {
+	AllowQuery bool
+}
+
+func NewValidator(token string) *Validator {
+	return &Validator{token: token}
+}
+
+func (v *Validator) ValidateToken(token string) bool {
+	return token != "" && token == v.token
+}
+
+func TokenFromRequest(r *http.Request, options RequestTokenOptions) string {
+	if token := TokenFromAuthorizationHeader(r.Header.Get("Authorization")); token != "" {
+		return token
+	}
+
+	if token := r.Header.Get("X-API-Token"); token != "" {
+		return token
+	}
+
+	if token := r.Header.Get("token"); token != "" {
+		return token
+	}
+
+	if options.AllowQuery {
+		return r.URL.Query().Get("token")
+	}
+
+	return ""
+}
+
+func TokenFromAuthorizationHeader(value string) string {
+	if value == "" {
+		return ""
+	}
+
+	prefix, token, ok := strings.Cut(value, " ")
+	if !ok || !strings.EqualFold(prefix, "Bearer") {
+		return ""
+	}
+
+	return strings.TrimSpace(token)
+}
+
+func WriteAuthenticationError(w http.ResponseWriter) {
+	writeJSONError(w, http.StatusInternalServerError, "Authentication error")
+}
+
+func WriteUnauthorized(w http.ResponseWriter) {
+	writeJSONError(w, http.StatusUnauthorized, "Invalid API token")
+}
+
+func writeJSONError(w http.ResponseWriter, status int, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]string{"error": message})
+}

--- a/backend/auth/auth_test.go
+++ b/backend/auth/auth_test.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTokenFromAuthorizationHeader(t *testing.T) {
+	assert.Equal(t, "test-token", TokenFromAuthorizationHeader("Bearer test-token"))
+	assert.Equal(t, "test-token", TokenFromAuthorizationHeader("bearer test-token"))
+	assert.Equal(t, "", TokenFromAuthorizationHeader("Basic test-token"))
+	assert.Equal(t, "", TokenFromAuthorizationHeader("test-token"))
+	assert.Equal(t, "", TokenFromAuthorizationHeader(""))
+}
+
+func TestTokenFromRequest(t *testing.T) {
+	t.Run("prefers bearer header", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/data/cpu?token=query-token", nil)
+		req.Header.Set("Authorization", "Bearer bearer-token")
+		req.Header.Set("X-API-Token", "header-token")
+
+		assert.Equal(t, "bearer-token", TokenFromRequest(req, RequestTokenOptions{AllowQuery: true}))
+	})
+
+	t.Run("falls back to legacy headers", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/data/cpu", nil)
+		req.Header.Set("X-API-Token", "header-token")
+
+		assert.Equal(t, "header-token", TokenFromRequest(req, RequestTokenOptions{}))
+
+		req = httptest.NewRequest("GET", "/api/data/cpu", nil)
+		req.Header.Set("token", "legacy-token")
+
+		assert.Equal(t, "legacy-token", TokenFromRequest(req, RequestTokenOptions{}))
+	})
+
+	t.Run("uses query token when enabled", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/media/file/data?token=query-token", nil)
+
+		assert.Equal(t, "query-token", TokenFromRequest(req, RequestTokenOptions{AllowQuery: true}))
+		assert.Equal(t, "", TokenFromRequest(req, RequestTokenOptions{}))
+	})
+}
+
+func TestValidatorValidateToken(t *testing.T) {
+	validator := NewValidator("expected-token")
+
+	assert.True(t, validator.ValidateToken("expected-token"))
+	assert.False(t, validator.ValidateToken("wrong-token"))
+	assert.False(t, validator.ValidateToken(""))
+}

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -12,6 +12,7 @@ import (
 
 	"log/slog"
 
+	backend_auth "github.com/timmo001/system-bridge/backend/auth"
 	api_http "github.com/timmo001/system-bridge/backend/http"
 	"github.com/timmo001/system-bridge/backend/mcp"
 	"github.com/timmo001/system-bridge/backend/websocket"
@@ -90,6 +91,7 @@ func (b *Backend) Run(ctx context.Context) error {
 
 	// Create a new HTTP server mux
 	mux := http.NewServeMux()
+	authValidator := backend_auth.NewValidator(b.token)
 
 	// Set up WebSocket endpoint
 	mux.HandleFunc("/api/websocket", func(w http.ResponseWriter, r *http.Request) {
@@ -118,6 +120,7 @@ func (b *Backend) Run(ctx context.Context) error {
 	// Set up module data endpoint
 	mux.HandleFunc("/api/data/", api_http.GetModuleDataHandler(
 		b.dataStore,
+		authValidator,
 	))
 
 	// Set up health check endpoint
@@ -142,7 +145,7 @@ func (b *Backend) Run(ctx context.Context) error {
 		}
 	})
 
-	mux.HandleFunc("/api/media/file/data", api_http.ServeMediaFileDataHandler)
+	mux.HandleFunc("/api/media/file/data", api_http.ServeMediaFileDataHandler(authValidator))
 
 	// Set up SPA file server (must be last to avoid catching API routes)
 	subFS, err := fs.Sub(b.webClientContent, "web-client/dist")

--- a/backend/http/data.go
+++ b/backend/http/data.go
@@ -6,36 +6,17 @@ import (
 
 	"log/slog"
 
+	backend_auth "github.com/timmo001/system-bridge/backend/auth"
 	"github.com/timmo001/system-bridge/data"
 	"github.com/timmo001/system-bridge/types"
-	"github.com/timmo001/system-bridge/utils"
 )
 
 // GetModuleDataHandler handles requests to get data for a specific module
-func GetModuleDataHandler(dataStore *data.DataStore) http.HandlerFunc {
+func GetModuleDataHandler(dataStore *data.DataStore, validator *backend_auth.Validator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		expectedToken, err := utils.LoadToken()
-		if err != nil {
-			slog.Error("Failed to load token for authentication", "error", err)
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusInternalServerError)
-			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Authentication error"}); err != nil {
-				slog.Error("Failed to encode response", "error", err)
-			}
-			return
-		}
-
-		// Check for API token in both X-API-Token and token headers
-		token := r.Header.Get("X-API-Token")
-		if token == "" {
-			token = r.Header.Get("token")
-		}
-		if token != expectedToken {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusUnauthorized)
-			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid API token"}); err != nil {
-				slog.Error("Failed to encode response", "error", err)
-			}
+		token := backend_auth.TokenFromRequest(r, backend_auth.RequestTokenOptions{})
+		if !validator.ValidateToken(token) {
+			backend_auth.WriteUnauthorized(w)
 			return
 		}
 

--- a/backend/http/data_test.go
+++ b/backend/http/data_test.go
@@ -1,0 +1,66 @@
+package http
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	backend_auth "github.com/timmo001/system-bridge/backend/auth"
+	"github.com/timmo001/system-bridge/data"
+)
+
+func TestGetModuleDataHandlerAuth(t *testing.T) {
+	dataStore, err := data.NewDataStore()
+	require.NoError(t, err)
+
+	handler := GetModuleDataHandler(dataStore, backend_auth.NewValidator("test-token"))
+
+	t.Run("rejects missing token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/data/cpu", nil)
+		rr := httptest.NewRecorder()
+
+		handler(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("accepts bearer token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/data/cpu", nil)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rr := httptest.NewRecorder()
+
+		handler(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+
+	t.Run("accepts legacy x-api-token header", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/data/cpu", nil)
+		req.Header.Set("X-API-Token", "test-token")
+		rr := httptest.NewRecorder()
+
+		handler(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+	})
+}
+
+func TestGetModuleDataHandlerReturnsJSONError(t *testing.T) {
+	dataStore, err := data.NewDataStore()
+	require.NoError(t, err)
+
+	handler := GetModuleDataHandler(dataStore, backend_auth.NewValidator("test-token"))
+	req := httptest.NewRequest(http.MethodGet, "/api/data/unknown", nil)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rr := httptest.NewRecorder()
+
+	handler(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+	var body map[string]string
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &body))
+	assert.Equal(t, "Module not found", body["error"])
+}

--- a/backend/http/media.go
+++ b/backend/http/media.go
@@ -10,158 +10,144 @@ import (
 	"runtime"
 	"strings"
 
+	backend_auth "github.com/timmo001/system-bridge/backend/auth"
 	"github.com/timmo001/system-bridge/settings"
-	"github.com/timmo001/system-bridge/utils"
 	"github.com/timmo001/system-bridge/utils/handlers/filesystem"
 )
 
 // ServeMediaFileDataHandler handles requests to serve media files from predefined base directories
-func ServeMediaFileDataHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusMethodNotAllowed)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Method not allowed"}); err != nil {
-			slog.Error("Failed to encode response", "error", err)
-		}
-		return
-	}
-
-	// Get query parameters
-	base := r.URL.Query().Get("base")
-	path := r.URL.Query().Get("path")
-	token := r.URL.Query().Get("token")
-
-	// Validate required parameters
-	if base == "" || path == "" || token == "" {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Missing required parameters: base, path, token"}); err != nil {
-			slog.Error("Failed to encode response", "error", err)
-		}
-		return
-	}
-
-	// Validate API token
-	expectedToken, err := utils.LoadToken()
-	if err != nil {
-		slog.Error("Failed to load token for authentication", "error", err)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Authentication error"}); err != nil {
-			slog.Error("Failed to encode response", "error", err)
-		}
-		return
-	}
-
-	if token != expectedToken {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusUnauthorized)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid API token"}); err != nil {
-			slog.Error("Failed to encode response", "error", err)
-		}
-		return
-	}
-
-	// Get base directory path
-	basePath, err := getBaseDirectoryPath(base)
-	if err != nil {
-		slog.Error("Invalid base directory", "base", base, "error", err)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid base directory"}); err != nil {
-			slog.Error("Failed to encode response", "error", err)
-		}
-		return
-	}
-
-	// Construct full file path
-	fullPath := filepath.Join(basePath, path)
-
-	// Security: Clean and validate path to prevent directory traversal
-	cleanPath := filepath.Clean(fullPath)
-	relPath, err := filepath.Rel(basePath, cleanPath)
-	if err != nil || strings.HasPrefix(relPath, "..") {
-		slog.Error("Path traversal attempt detected", "requested_path", fullPath, "base_path", basePath, "rel_path", relPath)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusForbidden)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Access denied"}); err != nil {
-			slog.Error("Failed to encode response", "error", err)
-		}
-		return
-	}
-
-	// Check if file exists
-	fileInfo, err := os.Stat(cleanPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			slog.Info("File not found", "path", cleanPath)
+func ServeMediaFileDataHandler(validator *backend_auth.Validator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(http.StatusNotFound)
-			if err := json.NewEncoder(w).Encode(map[string]string{"error": "File not found"}); err != nil {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Method not allowed"}); err != nil {
 				slog.Error("Failed to encode response", "error", err)
 			}
 			return
 		}
-		slog.Error("Failed to stat file", "path", cleanPath, "error", err)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusInternalServerError)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Internal server error"}); err != nil {
-			slog.Error("Failed to encode response", "error", err)
+
+		// Get query parameters
+		base := r.URL.Query().Get("base")
+		path := r.URL.Query().Get("path")
+
+		// Validate required parameters
+		if base == "" || path == "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Missing required parameters: base, path"}); err != nil {
+				slog.Error("Failed to encode response", "error", err)
+			}
+			return
 		}
-		return
-	}
 
-	// Ensure it's a regular file (not a directory)
-	if !fileInfo.Mode().IsRegular() {
-		slog.Error("Requested path is not a regular file", "path", cleanPath)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusBadRequest)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "Path is not a file"}); err != nil {
-			slog.Error("Failed to encode response", "error", err)
+		token := backend_auth.TokenFromRequest(r, backend_auth.RequestTokenOptions{AllowQuery: true})
+		if !validator.ValidateToken(token) {
+			backend_auth.WriteUnauthorized(w)
+			return
 		}
-		return
-	}
 
-	// Basic file type restrictions (allow common media types)
-	ext := strings.ToLower(filepath.Ext(cleanPath))
-	allowedExtensions := map[string]bool{
-		".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".bmp": true, ".webp": true,
-		".mp3": true, ".wav": true, ".flac": true, ".aac": true, ".ogg": true, ".m4a": true,
-		".mp4": true, ".avi": true, ".mkv": true, ".mov": true, ".wmv": true, ".webm": true,
-		".txt": true, ".pdf": true, ".doc": true, ".docx": true, ".xls": true, ".xlsx": true,
-	}
-
-	if !allowedExtensions[ext] {
-		slog.Error("File type not allowed", "extension", ext, "path", cleanPath)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusForbidden)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "File type not allowed"}); err != nil {
-			slog.Error("Failed to encode response", "error", err)
+		// Get base directory path
+		basePath, err := getBaseDirectoryPath(base)
+		if err != nil {
+			slog.Error("Invalid base directory", "base", base, "error", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Invalid base directory"}); err != nil {
+				slog.Error("Failed to encode response", "error", err)
+			}
+			return
 		}
-		return
-	}
 
-	// Size limit (100MB)
-	const maxFileSize = 100 * 1024 * 1024 // 100MB
-	if fileInfo.Size() > maxFileSize {
-		slog.Error("File too large", "size", fileInfo.Size(), "max_size", maxFileSize)
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusRequestEntityTooLarge)
-		if err := json.NewEncoder(w).Encode(map[string]string{"error": "File too large"}); err != nil {
-			slog.Error("Failed to encode response", "error", err)
+		// Construct full file path
+		fullPath := filepath.Join(basePath, path)
+
+		// Security: Clean and validate path to prevent directory traversal
+		cleanPath := filepath.Clean(fullPath)
+		relPath, err := filepath.Rel(basePath, cleanPath)
+		if err != nil || strings.HasPrefix(relPath, "..") {
+			slog.Error("Path traversal attempt detected", "requested_path", fullPath, "base_path", basePath, "rel_path", relPath)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Access denied"}); err != nil {
+				slog.Error("Failed to encode response", "error", err)
+			}
+			return
 		}
-		return
+
+		// Check if file exists
+		fileInfo, err := os.Stat(cleanPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				slog.Info("File not found", "path", cleanPath)
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusNotFound)
+				if err := json.NewEncoder(w).Encode(map[string]string{"error": "File not found"}); err != nil {
+					slog.Error("Failed to encode response", "error", err)
+				}
+				return
+			}
+			slog.Error("Failed to stat file", "path", cleanPath, "error", err)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Internal server error"}); err != nil {
+				slog.Error("Failed to encode response", "error", err)
+			}
+			return
+		}
+
+		// Ensure it's a regular file (not a directory)
+		if !fileInfo.Mode().IsRegular() {
+			slog.Error("Requested path is not a regular file", "path", cleanPath)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "Path is not a file"}); err != nil {
+				slog.Error("Failed to encode response", "error", err)
+			}
+			return
+		}
+
+		// Basic file type restrictions (allow common media types)
+		ext := strings.ToLower(filepath.Ext(cleanPath))
+		allowedExtensions := map[string]bool{
+			".jpg": true, ".jpeg": true, ".png": true, ".gif": true, ".bmp": true, ".webp": true,
+			".mp3": true, ".wav": true, ".flac": true, ".aac": true, ".ogg": true, ".m4a": true,
+			".mp4": true, ".avi": true, ".mkv": true, ".mov": true, ".wmv": true, ".webm": true,
+			".txt": true, ".pdf": true, ".doc": true, ".docx": true, ".xls": true, ".xlsx": true,
+		}
+
+		if !allowedExtensions[ext] {
+			slog.Error("File type not allowed", "extension", ext, "path", cleanPath)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "File type not allowed"}); err != nil {
+				slog.Error("Failed to encode response", "error", err)
+			}
+			return
+		}
+
+		// Size limit (100MB)
+		const maxFileSize = 100 * 1024 * 1024 // 100MB
+		if fileInfo.Size() > maxFileSize {
+			slog.Error("File too large", "size", fileInfo.Size(), "max_size", maxFileSize)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusRequestEntityTooLarge)
+			if err := json.NewEncoder(w).Encode(map[string]string{"error": "File too large"}); err != nil {
+				slog.Error("Failed to encode response", "error", err)
+			}
+			return
+		}
+
+		// Set appropriate headers
+		contentType := getContentType(cleanPath)
+		w.Header().Set("Content-Type", contentType)
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", fileInfo.Size()))
+		w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", filepath.Base(cleanPath)))
+
+		// Serve the file
+		slog.Info("Serving media file", "path", cleanPath, "size", fileInfo.Size())
+		http.ServeFile(w, r, cleanPath)
 	}
-
-	// Set appropriate headers
-	contentType := getContentType(cleanPath)
-	w.Header().Set("Content-Type", contentType)
-	w.Header().Set("Content-Length", fmt.Sprintf("%d", fileInfo.Size()))
-	w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s\"", filepath.Base(cleanPath)))
-
-	// Serve the file
-	slog.Info("Serving media file", "path", cleanPath, "size", fileInfo.Size())
-	http.ServeFile(w, r, cleanPath)
 }
 
 // getBaseDirectoryPath returns the absolute path for a base directory key

--- a/backend/http/media_test.go
+++ b/backend/http/media_test.go
@@ -1,0 +1,42 @@
+package http
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	backend_auth "github.com/timmo001/system-bridge/backend/auth"
+)
+
+func TestServeMediaFileDataHandlerAuth(t *testing.T) {
+	handler := ServeMediaFileDataHandler(backend_auth.NewValidator("test-token"))
+
+	t.Run("rejects missing token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/media/file/data?base=home&path=file.txt", nil)
+		rr := httptest.NewRecorder()
+
+		handler(rr, req)
+
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("accepts legacy query token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/media/file/data?base=missing&path=file.txt&token=test-token", nil)
+		rr := httptest.NewRecorder()
+
+		handler(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+
+	t.Run("accepts bearer token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/media/file/data?base=missing&path=file.txt", nil)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rr := httptest.NewRecorder()
+
+		handler(rr, req)
+
+		assert.Equal(t, http.StatusBadRequest, rr.Code)
+	})
+}

--- a/backend/mcp/server.go
+++ b/backend/mcp/server.go
@@ -6,6 +6,7 @@ import (
 
 	"log/slog"
 
+	backend_auth "github.com/timmo001/system-bridge/backend/auth"
 	"github.com/timmo001/system-bridge/data"
 	"github.com/timmo001/system-bridge/event"
 	"github.com/timmo001/system-bridge/version"
@@ -13,7 +14,7 @@ import (
 
 // MCPServer handles MCP protocol requests
 type MCPServer struct {
-	token       string
+	validator   *backend_auth.Validator
 	eventRouter *event.MessageRouter
 	dataStore   *data.DataStore
 }
@@ -21,7 +22,7 @@ type MCPServer struct {
 // NewMCPServer creates a new MCP server
 func NewMCPServer(token string, eventRouter *event.MessageRouter, dataStore *data.DataStore) *MCPServer {
 	return &MCPServer{
-		token:       token,
+		validator:   backend_auth.NewValidator(token),
 		eventRouter: eventRouter,
 		dataStore:   dataStore,
 	}

--- a/backend/mcp/transport.go
+++ b/backend/mcp/transport.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 
 	"github.com/gorilla/websocket"
+	backend_auth "github.com/timmo001/system-bridge/backend/auth"
 )
 
 var upgrader = websocket.Upgrader{
@@ -21,20 +22,10 @@ var upgrader = websocket.Upgrader{
 
 // HandleConnection handles a new MCP WebSocket connection
 func (s *MCPServer) HandleConnection(w http.ResponseWriter, r *http.Request) error {
-	// Check for token in query parameters or headers
-	token := r.URL.Query().Get("token")
-	if token == "" {
-		token = r.Header.Get("Authorization")
-		// Remove "Bearer " prefix if present
-		if len(token) > 7 && token[:7] == "Bearer " {
-			token = token[7:]
-		}
-	}
-
-	// Validate token
-	if token != s.token {
+	token := backend_auth.TokenFromRequest(r, backend_auth.RequestTokenOptions{AllowQuery: true})
+	if !s.validator.ValidateToken(token) {
 		slog.Warn("MCP connection rejected: invalid token")
-		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		backend_auth.WriteUnauthorized(w)
 		return nil
 	}
 

--- a/backend/mcp/transport_test.go
+++ b/backend/mcp/transport_test.go
@@ -1,0 +1,39 @@
+package mcp
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/timmo001/system-bridge/data"
+	"github.com/timmo001/system-bridge/event"
+)
+
+func TestHandleConnectionAuth(t *testing.T) {
+	dataStore, err := data.NewDataStore()
+	require.NoError(t, err)
+
+	server := NewMCPServer("test-token", event.NewMessageRouter(), dataStore)
+
+	t.Run("rejects missing token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/mcp", nil)
+		rr := httptest.NewRecorder()
+
+		err := server.HandleConnection(rr, req)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+
+	t.Run("rejects invalid token", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/mcp?token=wrong-token", nil)
+		rr := httptest.NewRecorder()
+
+		err := server.HandleConnection(rr, req)
+
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, rr.Code)
+	})
+}

--- a/backend/websocket/handlers.go
+++ b/backend/websocket/handlers.go
@@ -57,7 +57,7 @@ func (ws *WebsocketServer) handleMessages(conn *websocket.Conn) {
 		}
 
 		// Validate token
-		if msg.Token != ws.token {
+		if !ws.validator.ValidateToken(msg.Token) {
 			slog.Error("Invalid token received")
 			ws.SendError(conn, msg, "BAD_TOKEN", "Invalid token")
 			continue

--- a/backend/websocket/websocket.go
+++ b/backend/websocket/websocket.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/gorilla/websocket"
+	backend_auth "github.com/timmo001/system-bridge/backend/auth"
 	"github.com/timmo001/system-bridge/bus"
 	"github.com/timmo001/system-bridge/data"
 	"github.com/timmo001/system-bridge/event"
@@ -29,7 +30,7 @@ type connectionInfo struct {
 }
 
 type WebsocketServer struct {
-	token         string
+	validator     *backend_auth.Validator
 	upgrader      websocket.Upgrader
 	connections   map[string]*connectionInfo
 	dataListeners map[string][]types.ModuleName
@@ -40,7 +41,7 @@ type WebsocketServer struct {
 
 func NewWebsocketServer(token string, dataStore *data.DataStore, eventRouter *event.MessageRouter) *WebsocketServer {
 	ws := &WebsocketServer{
-		token:         token,
+		validator:     backend_auth.NewValidator(token),
 		connections:   make(map[string]*connectionInfo),
 		dataListeners: make(map[string][]types.ModuleName),
 		dataStore:     dataStore,


### PR DESCRIPTION
> [!NOTE]
> The following is an LLM summary 

This pull request introduces a unified API token authentication mechanism across the backend by creating a reusable `auth` package and refactoring all HTTP and WebSocket endpoints to use it. The authentication logic is now centralized, making it easier to maintain and extend. Comprehensive tests have been added for the new authentication flows.

The most important changes are:

**Authentication Refactor and Centralization:**
* Introduced a new `auth` package that provides a `Validator` type, token extraction utilities (supporting Bearer, legacy headers, and query tokens), and standardized error responses. All authentication logic is now handled through this package (`backend/auth/auth.go`, `backend/auth/auth_test.go`). [[1]](diffhunk://#diff-d37ee781c303688116370a7e1b8f267365835933a01f09d00e11694c7942f22dR1-R70) [[2]](diffhunk://#diff-20ba29262e288d15dc4c52e0b97cdecff4088cd2f037dc5efae6cae111972576R1-R53)
* Refactored all backend endpoints (HTTP, WebSocket, and MCP) to use the new `Validator` for token validation, replacing previous scattered and duplicated logic (`backend/backend.go`, `backend/http/data.go`, `backend/http/media.go`, `backend/mcp/server.go`, `backend/mcp/transport.go`, `backend/websocket/websocket.go`, `backend/websocket/handlers.go`). [[1]](diffhunk://#diff-ceb7e04e1612df83dc6c0f93e8dd3646a846c5949195088be13031f700264b67R15) [[2]](diffhunk://#diff-ceb7e04e1612df83dc6c0f93e8dd3646a846c5949195088be13031f700264b67R94) [[3]](diffhunk://#diff-ceb7e04e1612df83dc6c0f93e8dd3646a846c5949195088be13031f700264b67R123) [[4]](diffhunk://#diff-ceb7e04e1612df83dc6c0f93e8dd3646a846c5949195088be13031f700264b67L145-R148) [[5]](diffhunk://#diff-be9340101aa6e58fc4288c8901a9692acfda326eef1231abbf4d55077ff2cc2aR9-R19) [[6]](diffhunk://#diff-4b896842598db36aa2393731c951276920e27a648f9c1d703566a4d9e11dbf62R13-R20) [[7]](diffhunk://#diff-4b896842598db36aa2393731c951276920e27a648f9c1d703566a4d9e11dbf62L32-R46) [[8]](diffhunk://#diff-4b896842598db36aa2393731c951276920e27a648f9c1d703566a4d9e11dbf62R151) [[9]](diffhunk://#diff-2c1f1ea19f85bb9df346c5df76f36b4aa0c961ec78179f48e32e8776f18e7cefR9-R25) [[10]](diffhunk://#diff-3b910579458fe40bf477eb1ea03bf1c129300f766260cc27ee7b3f5e488c03ddR12) [[11]](diffhunk://#diff-3b910579458fe40bf477eb1ea03bf1c129300f766260cc27ee7b3f5e488c03ddL24-R28) [[12]](diffhunk://#diff-8da2fcb86b4ac3cabb9a41a8d806da82b5cef939adb7032afa9e8b5e24bba793L60-R60) [[13]](diffhunk://#diff-56c3e6b84ea02979c57de37afd3c02c75d93e49aea35b146092f5167a227229cR8) [[14]](diffhunk://#diff-56c3e6b84ea02979c57de37afd3c02c75d93e49aea35b146092f5167a227229cL32-R33) [[15]](diffhunk://#diff-56c3e6b84ea02979c57de37afd3c02c75d93e49aea35b146092f5167a227229cL43-R44)

**Improved Token Extraction:**
* Enhanced token extraction to prefer Bearer tokens, then legacy headers, and finally (optionally) query parameters, ensuring backward compatibility and flexibility for clients (`backend/auth/auth.go`).

**Testing Enhancements:**
* Added thorough unit tests for the new authentication logic and its integration with the module data, media file, and MCP endpoints (`backend/auth/auth_test.go`, `backend/http/data_test.go`, `backend/http/media_test.go`, `backend/mcp/transport_test.go`). [[1]](diffhunk://#diff-20ba29262e288d15dc4c52e0b97cdecff4088cd2f037dc5efae6cae111972576R1-R53) [[2]](diffhunk://#diff-5724d546b4f840b45e9fcd479968f4c2a0b34a05af2ecfb4cbc98a740d2ab0bcR1-R66) [[3]](diffhunk://#diff-766996fcd9089e2cf41c73d918163bc75dc6f84eaa3e87e29d79255bfba8934bR1-R42) [[4]](diffhunk://#diff-ad323a66e9bcfd2745ef9d2b973afde1a84bc42f436b941b0a90bca373d353c5R1-R39)

**Consistent Error Handling:**
* Standardized authentication error responses using JSON error payloads and appropriate HTTP status codes across all endpoints (`backend/auth/auth.go`, refactored handlers).

**Simplification and Code Cleanup:**
* Removed redundant code and utilities related to token loading and validation from various modules, now handled centrally by the `auth` package (`backend/http/data.go`, `backend/http/media.go`). [[1]](diffhunk://#diff-be9340101aa6e58fc4288c8901a9692acfda326eef1231abbf4d55077ff2cc2aR9-R19) [[2]](diffhunk://#diff-4b896842598db36aa2393731c951276920e27a648f9c1d703566a4d9e11dbf62L32-R46)

These changes make authentication more robust, maintainable, and easier to test across the backend.