### PR TITLE
Websocket Singleton

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -21,6 +21,7 @@ import (
 	"github.com/timmo001/system-bridge/event"
 	event_handler "github.com/timmo001/system-bridge/event/handler"
 	"github.com/timmo001/system-bridge/settings"
+	"github.com/timmo001/system-bridge/types"
 	"github.com/timmo001/system-bridge/utils"
 	"github.com/timmo001/system-bridge/utils/handlers/command"
 	"github.com/timmo001/system-bridge/version"
@@ -34,6 +35,18 @@ type Backend struct {
 	webClientContent *embed.FS
 	discoveryManager *discovery.DiscoveryManager
 	token            string
+}
+
+type dataListenerRegistry struct {
+	ws *websocket.WebsocketServer
+}
+
+func (r dataListenerRegistry) RegisterDataListener(connection string, modules []types.ModuleName) {
+	r.ws.RegisterDataListener(connection, modules)
+}
+
+func (r dataListenerRegistry) UnregisterDataListener(connection string) {
+	r.ws.UnregisterDataListener(connection)
 }
 
 func New(settings *settings.Settings, dataStore *data.DataStore, token string, webClientContent *embed.FS) *Backend {
@@ -86,7 +99,7 @@ func (b *Backend) Run(ctx context.Context) error {
 	command.SetServerContext(ctx)
 
 	// Setup event handlers
-	event_handler.RegisterHandlers(b.eventRouter, b.dataStore)
+	event_handler.RegisterHandlers(b.eventRouter, b.dataStore, dataListenerRegistry{ws: b.wsServer})
 
 	// Create a new HTTP server mux
 	mux := http.NewServeMux()

--- a/event/handler/data-listener_test.go
+++ b/event/handler/data-listener_test.go
@@ -1,0 +1,88 @@
+package event_handler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/timmo001/system-bridge/event"
+	"github.com/timmo001/system-bridge/types"
+)
+
+type fakeDataListenerRegistry struct {
+	registeredConnection   string
+	registeredModules      []types.ModuleName
+	unregisteredConnection string
+}
+
+func (f *fakeDataListenerRegistry) RegisterDataListener(connection string, modules []types.ModuleName) {
+	f.registeredConnection = connection
+	f.registeredModules = append([]types.ModuleName(nil), modules...)
+}
+
+func (f *fakeDataListenerRegistry) UnregisterDataListener(connection string) {
+	f.unregisteredConnection = connection
+}
+
+func TestRegisterDataListenerHandler(t *testing.T) {
+	t.Run("registers listener with decoded modules", func(t *testing.T) {
+		registry := &fakeDataListenerRegistry{}
+		router := event.NewMessageRouter()
+		RegisterRegisterDataListenerHandler(router, registry)
+
+		msg := event.Message{
+			ID:    "register-1",
+			Event: event.EventRegisterDataListener,
+			Data: map[string]interface{}{
+				"modules": []string{"cpu", "memory"},
+			},
+		}
+
+		response := router.HandleMessage("conn-1", msg)
+
+		assert.Equal(t, event.ResponseTypeDataListenerRegistered, response.Type)
+		assert.Equal(t, "Listener registered", response.Message)
+		assert.Equal(t, "conn-1", registry.registeredConnection)
+		assert.Equal(t, []types.ModuleName{types.ModuleCPU, types.ModuleMemory}, registry.registeredModules)
+
+		data, ok := response.Data.(RegisterDataListenerRequestData)
+		require.True(t, ok)
+		assert.Equal(t, []types.ModuleName{types.ModuleCPU, types.ModuleMemory}, data.Modules)
+	})
+
+	t.Run("returns bad request for invalid payload", func(t *testing.T) {
+		registry := &fakeDataListenerRegistry{}
+		router := event.NewMessageRouter()
+		RegisterRegisterDataListenerHandler(router, registry)
+
+		msg := event.Message{
+			ID:    "register-2",
+			Event: event.EventRegisterDataListener,
+			Data:  "invalid",
+		}
+
+		response := router.HandleMessage("conn-2", msg)
+
+		assert.Equal(t, event.ResponseTypeError, response.Type)
+		assert.Equal(t, event.ResponseSubtypeBadRequest, response.Subtype)
+		assert.Empty(t, registry.registeredConnection)
+		assert.Nil(t, registry.registeredModules)
+	})
+}
+
+func TestUnregisterDataListenerHandler(t *testing.T) {
+	registry := &fakeDataListenerRegistry{}
+	router := event.NewMessageRouter()
+	RegisterUnregisterDataListenerHandler(router, registry)
+
+	msg := event.Message{
+		ID:    "unregister-1",
+		Event: event.EventUnregisterDataListener,
+	}
+
+	response := router.HandleMessage("conn-3", msg)
+
+	assert.Equal(t, event.ResponseTypeDataListenerUnregistered, response.Type)
+	assert.Equal(t, "Listener unregistered", response.Message)
+	assert.Equal(t, "conn-3", registry.unregisteredConnection)
+}

--- a/event/handler/data-listener_test.go
+++ b/event/handler/data-listener_test.go
@@ -34,7 +34,7 @@ func TestRegisterDataListenerHandler(t *testing.T) {
 			ID:    "register-1",
 			Event: event.EventRegisterDataListener,
 			Data: map[string]interface{}{
-				"modules": []string{"cpu", "memory"},
+				"modules": []interface{}{"cpu", "memory"},
 			},
 		}
 
@@ -68,21 +68,58 @@ func TestRegisterDataListenerHandler(t *testing.T) {
 		assert.Empty(t, registry.registeredConnection)
 		assert.Nil(t, registry.registeredModules)
 	})
+
+	t.Run("returns error when registry is nil", func(t *testing.T) {
+		router := event.NewMessageRouter()
+		RegisterRegisterDataListenerHandler(router, nil)
+
+		msg := event.Message{
+			ID:    "register-3",
+			Event: event.EventRegisterDataListener,
+			Data: map[string]interface{}{
+				"modules": []interface{}{"cpu"},
+			},
+		}
+
+		response := router.HandleMessage("conn-1", msg)
+
+		assert.Equal(t, event.ResponseTypeError, response.Type)
+		assert.Equal(t, event.ResponseSubtypeNone, response.Subtype)
+		assert.Equal(t, "No websocket instance found", response.Message)
+	})
 }
 
 func TestUnregisterDataListenerHandler(t *testing.T) {
-	registry := &fakeDataListenerRegistry{}
-	router := event.NewMessageRouter()
-	RegisterUnregisterDataListenerHandler(router, registry)
+	t.Run("unregisters listener", func(t *testing.T) {
+		registry := &fakeDataListenerRegistry{}
+		router := event.NewMessageRouter()
+		RegisterUnregisterDataListenerHandler(router, registry)
 
-	msg := event.Message{
-		ID:    "unregister-1",
-		Event: event.EventUnregisterDataListener,
-	}
+		msg := event.Message{
+			ID:    "unregister-1",
+			Event: event.EventUnregisterDataListener,
+		}
 
-	response := router.HandleMessage("conn-3", msg)
+		response := router.HandleMessage("conn-3", msg)
 
-	assert.Equal(t, event.ResponseTypeDataListenerUnregistered, response.Type)
-	assert.Equal(t, "Listener unregistered", response.Message)
-	assert.Equal(t, "conn-3", registry.unregisteredConnection)
+		assert.Equal(t, event.ResponseTypeDataListenerUnregistered, response.Type)
+		assert.Equal(t, "Listener unregistered", response.Message)
+		assert.Equal(t, "conn-3", registry.unregisteredConnection)
+	})
+
+	t.Run("returns error when registry is nil", func(t *testing.T) {
+		router := event.NewMessageRouter()
+		RegisterUnregisterDataListenerHandler(router, nil)
+
+		msg := event.Message{
+			ID:    "unregister-2",
+			Event: event.EventUnregisterDataListener,
+		}
+
+		response := router.HandleMessage("conn-3", msg)
+
+		assert.Equal(t, event.ResponseTypeError, response.Type)
+		assert.Equal(t, event.ResponseSubtypeNone, response.Subtype)
+		assert.Equal(t, "No websocket instance found", response.Message)
+	})
 }

--- a/event/handler/handler.go
+++ b/event/handler/handler.go
@@ -3,9 +3,15 @@ package event_handler
 import (
 	"github.com/timmo001/system-bridge/data"
 	"github.com/timmo001/system-bridge/event"
+	"github.com/timmo001/system-bridge/types"
 )
 
-func RegisterHandlers(router *event.MessageRouter, dataStore *data.DataStore) {
+type DataListenerRegistry interface {
+	RegisterDataListener(connection string, modules []types.ModuleName)
+	UnregisterDataListener(connection string)
+}
+
+func RegisterHandlers(router *event.MessageRouter, dataStore *data.DataStore, listeners DataListenerRegistry) {
 	RegisterExitApplicationHandler(router)
 	RegisterGetDataHandler(router)
 	RegisterGetDirectoriesHandler(router)
@@ -24,8 +30,8 @@ func RegisterHandlers(router *event.MessageRouter, dataStore *data.DataStore) {
 	RegisterPowerRestartHandler(router)
 	RegisterPowerShutdownHandler(router)
 	RegisterPowerSleepHandler(router)
-	RegisterRegisterDataListenerHandler(router)
-	RegisterUnregisterDataListenerHandler(router)
+	RegisterRegisterDataListenerHandler(router, listeners)
+	RegisterUnregisterDataListenerHandler(router, listeners)
 	RegisterCommandExecuteHandler(router)
 	RegisterUpdateSettingsHandler(router)
 	RegisterValidateDirectoryHandler(router)

--- a/event/handler/register-data-listener.go
+++ b/event/handler/register-data-listener.go
@@ -4,7 +4,6 @@ import (
 	"log/slog"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/timmo001/system-bridge/backend/websocket"
 	"github.com/timmo001/system-bridge/event"
 	"github.com/timmo001/system-bridge/types"
 )
@@ -13,7 +12,7 @@ type RegisterDataListenerRequestData struct {
 	Modules []types.ModuleName `json:"modules" mapstructure:"modules"`
 }
 
-func RegisterRegisterDataListenerHandler(router *event.MessageRouter) {
+func RegisterRegisterDataListenerHandler(router *event.MessageRouter, listeners DataListenerRegistry) {
 	router.RegisterSimpleHandler(event.EventRegisterDataListener, func(connection string, message event.Message) event.MessageResponse {
 		slog.Debug("Received register data listener event", "message", message)
 
@@ -27,18 +26,7 @@ func RegisterRegisterDataListenerHandler(router *event.MessageRouter) {
 			}
 		}
 
-		ws := websocket.GetInstance()
-		if ws == nil {
-			slog.Error("No websocket instance found")
-			return event.MessageResponse{
-				ID:      message.ID,
-				Type:    event.ResponseTypeError,
-				Subtype: event.ResponseSubtypeNone,
-				Message: "No websocket instance found",
-			}
-		}
-
-		ws.RegisterDataListener(connection, data.Modules)
+		listeners.RegisterDataListener(connection, data.Modules)
 
 		return event.MessageResponse{
 			ID:      message.ID,

--- a/event/handler/register-data-listener.go
+++ b/event/handler/register-data-listener.go
@@ -26,6 +26,16 @@ func RegisterRegisterDataListenerHandler(router *event.MessageRouter, listeners 
 			}
 		}
 
+		if listeners == nil {
+			slog.Error("No websocket instance found")
+			return event.MessageResponse{
+				ID:      message.ID,
+				Type:    event.ResponseTypeError,
+				Subtype: event.ResponseSubtypeNone,
+				Message: "No websocket instance found",
+			}
+		}
+
 		listeners.RegisterDataListener(connection, data.Modules)
 
 		return event.MessageResponse{

--- a/event/handler/unregister-data-listener.go
+++ b/event/handler/unregister-data-listener.go
@@ -10,6 +10,16 @@ func RegisterUnregisterDataListenerHandler(router *event.MessageRouter, listener
 	router.RegisterSimpleHandler(event.EventUnregisterDataListener, func(connection string, message event.Message) event.MessageResponse {
 		slog.Debug("Received unregister data listener event", "message", message)
 
+		if listeners == nil {
+			slog.Error("No websocket instance found")
+			return event.MessageResponse{
+				ID:      message.ID,
+				Type:    event.ResponseTypeError,
+				Subtype: event.ResponseSubtypeNone,
+				Message: "No websocket instance found",
+			}
+		}
+
 		listeners.UnregisterDataListener(connection)
 
 		return event.MessageResponse{

--- a/event/handler/unregister-data-listener.go
+++ b/event/handler/unregister-data-listener.go
@@ -3,26 +3,14 @@ package event_handler
 import (
 	"log/slog"
 
-	"github.com/timmo001/system-bridge/backend/websocket"
 	"github.com/timmo001/system-bridge/event"
 )
 
-func RegisterUnregisterDataListenerHandler(router *event.MessageRouter) {
+func RegisterUnregisterDataListenerHandler(router *event.MessageRouter, listeners DataListenerRegistry) {
 	router.RegisterSimpleHandler(event.EventUnregisterDataListener, func(connection string, message event.Message) event.MessageResponse {
 		slog.Debug("Received unregister data listener event", "message", message)
 
-		ws := websocket.GetInstance()
-		if ws == nil {
-			slog.Error("No websocket instance found")
-			return event.MessageResponse{
-				ID:      message.ID,
-				Type:    event.ResponseTypeError,
-				Subtype: event.ResponseSubtypeNone,
-				Message: "No websocket instance found",
-			}
-		}
-
-		ws.UnregisterDataListener(connection)
+		listeners.UnregisterDataListener(connection)
 
 		return event.MessageResponse{
 			ID:      message.ID,


### PR DESCRIPTION
> [!NOTE]
> The following is an LLM summary 

This pull request refactors the data listener registration and unregistration logic to use a new `DataListenerRegistry` interface, improving modularity and testability. It also introduces unit tests for the new handler logic. The most important changes are:

### Refactoring and Abstraction

* Introduced a `DataListenerRegistry` interface in `event/handler/handler.go` to abstract data listener management, replacing direct dependencies on the WebSocket implementation.
* Updated `RegisterRegisterDataListenerHandler` and `RegisterUnregisterDataListenerHandler` to accept a `DataListenerRegistry` parameter and use it instead of directly accessing the WebSocket instance. [[1]](diffhunk://#diff-5f00de31fa09a4ac4b8bf1c93ff0f72158ccdd64e7bea12f94b9efefeb532614L16-R15) [[2]](diffhunk://#diff-a261896c473adfb5dbc01cbb2cfb39cb610ecc0f5450b8041a7d36023747eb37L6-R13)
* Modified the `RegisterHandlers` function to require a `DataListenerRegistry` and pass it to the relevant handler registration functions.

### Backend Integration

* Implemented a concrete `dataListenerRegistry` type in `backend/backend.go` that wraps the WebSocket server and conforms to the new interface, updating handler registration accordingly. [[1]](diffhunk://#diff-ceb7e04e1612df83dc6c0f93e8dd3646a846c5949195088be13031f700264b67R40-R51) [[2]](diffhunk://#diff-ceb7e04e1612df83dc6c0f93e8dd3646a846c5949195088be13031f700264b67L89-R102)

### Testing

* Added `event/handler/data-listener_test.go` with unit tests for data listener registration and unregistration handlers, using a fake registry to verify behavior.

These changes collectively make the event handler logic more modular, easier to test, and decoupled from specific implementations.