### PR TITLE
Shared app service

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -14,6 +14,7 @@ import (
 
 	api_http "github.com/timmo001/system-bridge/backend/http"
 	"github.com/timmo001/system-bridge/backend/mcp"
+	"github.com/timmo001/system-bridge/backend/service"
 	"github.com/timmo001/system-bridge/backend/websocket"
 	"github.com/timmo001/system-bridge/bus"
 	"github.com/timmo001/system-bridge/data"
@@ -21,6 +22,7 @@ import (
 	"github.com/timmo001/system-bridge/event"
 	event_handler "github.com/timmo001/system-bridge/event/handler"
 	"github.com/timmo001/system-bridge/settings"
+	"github.com/timmo001/system-bridge/types"
 	"github.com/timmo001/system-bridge/utils"
 	"github.com/timmo001/system-bridge/utils/handlers/command"
 	"github.com/timmo001/system-bridge/version"
@@ -31,6 +33,7 @@ type Backend struct {
 	dataStore        *data.DataStore
 	eventRouter      *event.MessageRouter
 	wsServer         *websocket.WebsocketServer
+	service          *service.Service
 	webClientContent *embed.FS
 	discoveryManager *discovery.DiscoveryManager
 	token            string
@@ -43,6 +46,13 @@ func New(settings *settings.Settings, dataStore *data.DataStore, token string, w
 
 	eventRouter := event.NewMessageRouter()
 	wsServer := websocket.NewWebsocketServer(token, dataStore, eventRouter)
+	backendService := service.New(
+		dataStore,
+		func(connection string, modules []types.ModuleName) {
+			wsServer.RegisterDataListener(connection, modules)
+		},
+		wsServer.UnregisterDataListener,
+	)
 
 	// Initialize discovery manager
 	discoveryManager := discovery.NewDiscoveryManager(utils.GetPort())
@@ -52,6 +62,7 @@ func New(settings *settings.Settings, dataStore *data.DataStore, token string, w
 		dataStore:        dataStore,
 		eventRouter:      eventRouter,
 		wsServer:         wsServer,
+		service:          backendService,
 		webClientContent: webClientContent,
 		discoveryManager: discoveryManager,
 		token:            token,
@@ -86,7 +97,7 @@ func (b *Backend) Run(ctx context.Context) error {
 	command.SetServerContext(ctx)
 
 	// Setup event handlers
-	event_handler.RegisterHandlers(b.eventRouter, b.dataStore)
+	event_handler.RegisterHandlers(b.eventRouter, b.service)
 
 	// Create a new HTTP server mux
 	mux := http.NewServeMux()
@@ -117,7 +128,7 @@ func (b *Backend) Run(ctx context.Context) error {
 	mux.HandleFunc("/api", api_http.HandleAPI)
 	// Set up module data endpoint
 	mux.HandleFunc("/api/data/", api_http.GetModuleDataHandler(
-		b.dataStore,
+		b.service,
 	))
 
 	// Set up health check endpoint

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -117,7 +117,7 @@ func (b *Backend) Run(ctx context.Context) error {
 	})
 
 	// Set up MCP WebSocket endpoint
-	mcpServer := mcp.NewMCPServer(b.token, b.eventRouter, b.dataStore)
+	mcpServer := mcp.NewMCPServerWithService(b.token, b.eventRouter, b.service)
 	mux.HandleFunc("/api/mcp", func(w http.ResponseWriter, r *http.Request) {
 		if err := mcpServer.HandleConnection(w, r); err != nil {
 			slog.Error("MCP connection error", "error", err)

--- a/backend/http/data.go
+++ b/backend/http/data.go
@@ -6,13 +6,13 @@ import (
 
 	"log/slog"
 
-	"github.com/timmo001/system-bridge/data"
+	"github.com/timmo001/system-bridge/backend/service"
 	"github.com/timmo001/system-bridge/types"
 	"github.com/timmo001/system-bridge/utils"
 )
 
 // GetModuleDataHandler handles requests to get data for a specific module
-func GetModuleDataHandler(dataStore *data.DataStore) http.HandlerFunc {
+func GetModuleDataHandler(backendService *service.Service) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		expectedToken, err := utils.LoadToken()
 		if err != nil {
@@ -53,7 +53,7 @@ func GetModuleDataHandler(dataStore *data.DataStore) http.HandlerFunc {
 		}
 
 		// Get module data
-		m, err := dataStore.GetModule(module)
+		m, err := backendService.GetModule(module)
 		if err != nil {
 			slog.Info("GET: /api/data/:module", "module", module, "data", "not found")
 			w.Header().Set("Content-Type", "application/json")

--- a/backend/mcp/handlers.go
+++ b/backend/mcp/handlers.go
@@ -50,14 +50,9 @@ func (s *MCPServer) handleGetData(ctx context.Context, arguments map[string]inte
 	}
 
 	// Get data for each module
-	result := make(map[string]interface{})
-	for _, moduleName := range modules {
-		module, err := s.dataStore.GetModule(moduleName)
-		if err != nil {
-			slog.Warn("Module not found", "module", moduleName, "error", err)
-			continue
-		}
-		result[string(moduleName)] = module.Data
+	result, err := s.service.GetModules(modules)
+	if err != nil {
+		return nil, err
 	}
 
 	return result, nil
@@ -84,20 +79,23 @@ func (s *MCPServer) handleNotification(ctx context.Context, arguments map[string
 
 // handleMediaControl controls media playback
 func (s *MCPServer) handleMediaControl(ctx context.Context, arguments map[string]interface{}) (interface{}, error) {
-	message := event.Message{
-		ID:    generateID(),
-		Event: event.EventMediaControl,
-		Data:  arguments,
+	actionRaw, ok := arguments["action"]
+	if !ok {
+		return nil, fmt.Errorf("missing required parameter: action")
 	}
 
-	response := s.eventRouter.HandleMessage("mcp", message)
-	if response.Type == event.ResponseTypeError {
-		return nil, fmt.Errorf("%s", response.Message)
+	action, ok := actionRaw.(string)
+	if !ok {
+		return nil, fmt.Errorf("action must be a string")
+	}
+
+	if err := s.service.MediaControl(action); err != nil {
+		return nil, err
 	}
 
 	return map[string]interface{}{
 		"success": true,
-		"message": response.Message,
+		"message": "Media controlled",
 	}, nil
 }
 

--- a/backend/mcp/server.go
+++ b/backend/mcp/server.go
@@ -19,12 +19,18 @@ type MCPServer struct {
 	service     *service.Service
 }
 
-// NewMCPServer creates a new MCP server
+// NewMCPServer creates a new MCP server from a datastore.
+// Prefer NewMCPServerWithService in production wiring when a shared service already exists.
 func NewMCPServer(token string, eventRouter *event.MessageRouter, dataStore *data.DataStore) *MCPServer {
+	return NewMCPServerWithService(token, eventRouter, service.New(dataStore, nil, nil))
+}
+
+// NewMCPServerWithService creates a new MCP server using the shared backend service.
+func NewMCPServerWithService(token string, eventRouter *event.MessageRouter, backendService *service.Service) *MCPServer {
 	return &MCPServer{
 		token:       token,
 		eventRouter: eventRouter,
-		service:     service.New(dataStore, nil, nil),
+		service:     backendService,
 	}
 }
 

--- a/backend/mcp/server.go
+++ b/backend/mcp/server.go
@@ -6,6 +6,7 @@ import (
 
 	"log/slog"
 
+	"github.com/timmo001/system-bridge/backend/service"
 	"github.com/timmo001/system-bridge/data"
 	"github.com/timmo001/system-bridge/event"
 	"github.com/timmo001/system-bridge/version"
@@ -15,7 +16,7 @@ import (
 type MCPServer struct {
 	token       string
 	eventRouter *event.MessageRouter
-	dataStore   *data.DataStore
+	service     *service.Service
 }
 
 // NewMCPServer creates a new MCP server
@@ -23,7 +24,7 @@ func NewMCPServer(token string, eventRouter *event.MessageRouter, dataStore *dat
 	return &MCPServer{
 		token:       token,
 		eventRouter: eventRouter,
-		dataStore:   dataStore,
+		service:     service.New(dataStore, nil, nil),
 	}
 }
 

--- a/backend/service/service.go
+++ b/backend/service/service.go
@@ -1,0 +1,90 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/timmo001/system-bridge/data"
+	"github.com/timmo001/system-bridge/types"
+	"github.com/timmo001/system-bridge/utils/handlers/media"
+)
+
+type Service struct {
+	dataStore              *data.DataStore
+	registerDataListener   func(string, []types.ModuleName)
+	unregisterDataListener func(string)
+}
+
+func New(
+	dataStore *data.DataStore,
+	registerDataListener func(string, []types.ModuleName),
+	unregisterDataListener func(string),
+) *Service {
+	return &Service{
+		dataStore:              dataStore,
+		registerDataListener:   registerDataListener,
+		unregisterDataListener: unregisterDataListener,
+	}
+}
+
+func (s *Service) GetModule(name types.ModuleName) (types.Module, error) {
+	if s == nil || s.dataStore == nil {
+		return types.Module{}, fmt.Errorf("data service unavailable")
+	}
+
+	return s.dataStore.GetModule(name)
+}
+
+func (s *Service) GetModules(names []types.ModuleName) (map[string]any, error) {
+	if s == nil || s.dataStore == nil {
+		return nil, fmt.Errorf("data service unavailable")
+	}
+
+	result := make(map[string]any, len(names))
+	for _, name := range names {
+		module, err := s.dataStore.GetModule(name)
+		if err != nil {
+			continue
+		}
+		result[string(name)] = module.Data
+	}
+
+	return result, nil
+}
+
+func (s *Service) RegisterDataListener(connection string, modules []types.ModuleName) error {
+	if s == nil || s.registerDataListener == nil {
+		return fmt.Errorf("data listener service unavailable")
+	}
+
+	s.registerDataListener(connection, modules)
+	return nil
+}
+
+func (s *Service) UnregisterDataListener(connection string) error {
+	if s == nil || s.unregisterDataListener == nil {
+		return fmt.Errorf("data listener service unavailable")
+	}
+
+	s.unregisterDataListener(connection)
+	return nil
+}
+
+func (s *Service) MediaControl(action string) error {
+	if action == "" {
+		return fmt.Errorf("no action provided for media control")
+	}
+
+	if err := media.Control(media.MediaAction(action)); err != nil {
+		return err
+	}
+
+	if s == nil || s.dataStore == nil {
+		return nil
+	}
+
+	if err := s.dataStore.TriggerModuleUpdate(types.ModuleMedia); err != nil {
+		return fmt.Errorf("failed to trigger media module update: %w", err)
+	}
+
+	return nil
+}

--- a/backend/service/service.go
+++ b/backend/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/timmo001/system-bridge/data"
 	"github.com/timmo001/system-bridge/types"
@@ -83,7 +84,7 @@ func (s *Service) MediaControl(action string) error {
 	}
 
 	if err := s.dataStore.TriggerModuleUpdate(types.ModuleMedia); err != nil {
-		return fmt.Errorf("failed to trigger media module update: %w", err)
+		slog.Warn("Failed to trigger media module update after media control action", "action", action, "error", err)
 	}
 
 	return nil

--- a/backend/websocket/handlers.go
+++ b/backend/websocket/handlers.go
@@ -225,7 +225,7 @@ func (ws *WebsocketServer) handleGetDataModule(event bus.Event) {
 	for _, moduleName := range moduleRequest.Modules {
 		slog.Debug("WS: Broadcasting module update", "module", moduleName)
 
-		module, err := ws.dataStore.GetModule(moduleName)
+		module, err := ws.service.GetModule(moduleName)
 		if err != nil {
 			slog.Warn("Data module not registered", "module", moduleName)
 			continue

--- a/backend/websocket/websocket.go
+++ b/backend/websocket/websocket.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/gorilla/websocket"
+	"github.com/timmo001/system-bridge/backend/service"
 	"github.com/timmo001/system-bridge/bus"
 	"github.com/timmo001/system-bridge/data"
 	"github.com/timmo001/system-bridge/event"
@@ -35,6 +36,7 @@ type WebsocketServer struct {
 	dataListeners map[string][]types.ModuleName
 	mutex         sync.RWMutex
 	dataStore     *data.DataStore
+	service       *service.Service
 	EventRouter   *event.MessageRouter
 }
 
@@ -51,6 +53,13 @@ func NewWebsocketServer(token string, dataStore *data.DataStore, eventRouter *ev
 			},
 		},
 	}
+	ws.service = service.New(
+		dataStore,
+		func(addr string, modules []types.ModuleName) {
+			ws.RegisterDataListener(addr, modules)
+		},
+		ws.UnregisterDataListener,
+	)
 	SetInstance(ws)
 
 	// Subscribe to module data updates

--- a/event/handler/handler.go
+++ b/event/handler/handler.go
@@ -1,11 +1,11 @@
 package event_handler
 
 import (
-	"github.com/timmo001/system-bridge/data"
+	"github.com/timmo001/system-bridge/backend/service"
 	"github.com/timmo001/system-bridge/event"
 )
 
-func RegisterHandlers(router *event.MessageRouter, dataStore *data.DataStore) {
+func RegisterHandlers(router *event.MessageRouter, backendService *service.Service) {
 	RegisterExitApplicationHandler(router)
 	RegisterGetDataHandler(router)
 	RegisterGetDirectoriesHandler(router)
@@ -15,7 +15,7 @@ func RegisterHandlers(router *event.MessageRouter, dataStore *data.DataStore) {
 	RegisterGetSettingsHandler(router)
 	RegisterKeyboardKeypressHandler(router)
 	RegisterKeyboardTextHandler(router)
-	RegisterMediaControlHandler(router, dataStore)
+	RegisterMediaControlHandler(router, backendService)
 	RegisterNotificationHandler(router)
 	RegisterOpenHandler(router)
 	RegisterPowerHibernateHandler(router)
@@ -24,8 +24,8 @@ func RegisterHandlers(router *event.MessageRouter, dataStore *data.DataStore) {
 	RegisterPowerRestartHandler(router)
 	RegisterPowerShutdownHandler(router)
 	RegisterPowerSleepHandler(router)
-	RegisterRegisterDataListenerHandler(router)
-	RegisterUnregisterDataListenerHandler(router)
+	RegisterRegisterDataListenerHandler(router, backendService)
+	RegisterUnregisterDataListenerHandler(router, backendService)
 	RegisterCommandExecuteHandler(router)
 	RegisterUpdateSettingsHandler(router)
 	RegisterValidateDirectoryHandler(router)

--- a/event/handler/media-control.go
+++ b/event/handler/media-control.go
@@ -4,17 +4,15 @@ import (
 	"log/slog"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/timmo001/system-bridge/data"
+	"github.com/timmo001/system-bridge/backend/service"
 	"github.com/timmo001/system-bridge/event"
-	"github.com/timmo001/system-bridge/types"
-	"github.com/timmo001/system-bridge/utils/handlers/media"
 )
 
 type MediaControlRequestData struct {
 	Action string `json:"action" mapstructure:"action"`
 }
 
-func RegisterMediaControlHandler(router *event.MessageRouter, dataStore *data.DataStore) {
+func RegisterMediaControlHandler(router *event.MessageRouter, backendService *service.Service) {
 	router.RegisterSimpleHandler(event.EventMediaControl, func(connection string, message event.Message) event.MessageResponse {
 		slog.Debug("Received media control event", "message", message)
 
@@ -41,7 +39,7 @@ func RegisterMediaControlHandler(router *event.MessageRouter, dataStore *data.Da
 			}
 		}
 
-		err = media.Control(media.MediaAction(data.Action))
+		err = backendService.MediaControl(data.Action)
 		if err != nil {
 			slog.Error("Failed to control media", "error", err)
 			return event.MessageResponse{
@@ -49,15 +47,6 @@ func RegisterMediaControlHandler(router *event.MessageRouter, dataStore *data.Da
 				Type:    event.ResponseTypeError,
 				Subtype: event.ResponseSubtypeNone,
 				Message: "Failed to control media",
-			}
-		}
-
-		// Trigger an update to the media module
-		if dataStore != nil {
-			if err := dataStore.TriggerModuleUpdate(types.ModuleMedia); err != nil {
-				slog.Warn("Failed to trigger media module update", "error", err)
-			} else {
-				slog.Debug("Triggered media module update after media control action", "action", data.Action)
 			}
 		}
 

--- a/event/handler/register-data-listener.go
+++ b/event/handler/register-data-listener.go
@@ -4,7 +4,7 @@ import (
 	"log/slog"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/timmo001/system-bridge/backend/websocket"
+	"github.com/timmo001/system-bridge/backend/service"
 	"github.com/timmo001/system-bridge/event"
 	"github.com/timmo001/system-bridge/types"
 )
@@ -13,7 +13,7 @@ type RegisterDataListenerRequestData struct {
 	Modules []types.ModuleName `json:"modules" mapstructure:"modules"`
 }
 
-func RegisterRegisterDataListenerHandler(router *event.MessageRouter) {
+func RegisterRegisterDataListenerHandler(router *event.MessageRouter, backendService *service.Service) {
 	router.RegisterSimpleHandler(event.EventRegisterDataListener, func(connection string, message event.Message) event.MessageResponse {
 		slog.Debug("Received register data listener event", "message", message)
 
@@ -27,18 +27,15 @@ func RegisterRegisterDataListenerHandler(router *event.MessageRouter) {
 			}
 		}
 
-		ws := websocket.GetInstance()
-		if ws == nil {
-			slog.Error("No websocket instance found")
+		if err := backendService.RegisterDataListener(connection, data.Modules); err != nil {
+			slog.Error("Failed to register data listener", "error", err)
 			return event.MessageResponse{
 				ID:      message.ID,
 				Type:    event.ResponseTypeError,
 				Subtype: event.ResponseSubtypeNone,
-				Message: "No websocket instance found",
+				Message: "Failed to register data listener",
 			}
 		}
-
-		ws.RegisterDataListener(connection, data.Modules)
 
 		return event.MessageResponse{
 			ID:      message.ID,

--- a/event/handler/unregister-data-listener.go
+++ b/event/handler/unregister-data-listener.go
@@ -3,26 +3,23 @@ package event_handler
 import (
 	"log/slog"
 
-	"github.com/timmo001/system-bridge/backend/websocket"
+	"github.com/timmo001/system-bridge/backend/service"
 	"github.com/timmo001/system-bridge/event"
 )
 
-func RegisterUnregisterDataListenerHandler(router *event.MessageRouter) {
+func RegisterUnregisterDataListenerHandler(router *event.MessageRouter, backendService *service.Service) {
 	router.RegisterSimpleHandler(event.EventUnregisterDataListener, func(connection string, message event.Message) event.MessageResponse {
 		slog.Debug("Received unregister data listener event", "message", message)
 
-		ws := websocket.GetInstance()
-		if ws == nil {
-			slog.Error("No websocket instance found")
+		if err := backendService.UnregisterDataListener(connection); err != nil {
+			slog.Error("Failed to unregister data listener", "error", err)
 			return event.MessageResponse{
 				ID:      message.ID,
 				Type:    event.ResponseTypeError,
 				Subtype: event.ResponseSubtypeNone,
-				Message: "No websocket instance found",
+				Message: "Failed to unregister data listener",
 			}
 		}
-
-		ws.UnregisterDataListener(connection)
 
 		return event.MessageResponse{
 			ID:      message.ID,


### PR DESCRIPTION
> [!NOTE]
> The following is an LLM summary 

This pull request introduces a new `Service` layer to centralize backend business logic, refactoring the codebase to route data access and control operations through this service. The change enhances maintainability and encapsulation by decoupling direct data store access from various components, and by consolidating media control and data listener registration logic.

Key changes include:

**Introduction of Service Layer:**

* Added a new `Service` struct in `backend/service/service.go` that wraps the `DataStore` and provides methods for module data access, media control, and data listener registration/unregistration.

**Refactoring to Use Service Layer:**

* Updated `Backend`, `WebsocketServer`, and `MCPServer` to initialize and use the new `Service` instance instead of accessing the `DataStore` directly. This includes changes in their constructors and relevant method calls. [[1]](diffhunk://#diff-ceb7e04e1612df83dc6c0f93e8dd3646a846c5949195088be13031f700264b67R17-R25) [[2]](diffhunk://#diff-ceb7e04e1612df83dc6c0f93e8dd3646a846c5949195088be13031f700264b67R36) [[3]](diffhunk://#diff-ceb7e04e1612df83dc6c0f93e8dd3646a846c5949195088be13031f700264b67R49-R55) [[4]](diffhunk://#diff-ceb7e04e1612df83dc6c0f93e8dd3646a846c5949195088be13031f700264b67R65) [[5]](diffhunk://#diff-56c3e6b84ea02979c57de37afd3c02c75d93e49aea35b146092f5167a227229cR8) [[6]](diffhunk://#diff-56c3e6b84ea02979c57de37afd3c02c75d93e49aea35b146092f5167a227229cR39) [[7]](diffhunk://#diff-56c3e6b84ea02979c57de37afd3c02c75d93e49aea35b146092f5167a227229cR56-R62) [[8]](diffhunk://#diff-2c1f1ea19f85bb9df346c5df76f36b4aa0c961ec78179f48e32e8776f18e7cefR9) [[9]](diffhunk://#diff-2c1f1ea19f85bb9df346c5df76f36b4aa0c961ec78179f48e32e8776f18e7cefL18-R27)

* Modified HTTP and WebSocket handlers to use the `Service` for fetching module data, replacing direct calls to `DataStore`. [[1]](diffhunk://#diff-be9340101aa6e58fc4288c8901a9692acfda326eef1231abbf4d55077ff2cc2aL9-R15) [[2]](diffhunk://#diff-be9340101aa6e58fc4288c8901a9692acfda326eef1231abbf4d55077ff2cc2aL56-R56) [[3]](diffhunk://#diff-8da2fcb86b4ac3cabb9a41a8d806da82b5cef939adb7032afa9e8b5e24bba793L228-R228)

**Event Handler Refactoring:**

* Changed event handler registration functions to accept a `Service` instance instead of a `DataStore`, and updated the media control and data listener registration/unregistration handlers to use the new service methods. [[1]](diffhunk://#diff-68c8c087f999419d20a193cd7a73e20d2616063816f91a2034ed8efcdecdeba7L4-R8) [[2]](diffhunk://#diff-68c8c087f999419d20a193cd7a73e20d2616063816f91a2034ed8efcdecdeba7L18-R18) [[3]](diffhunk://#diff-68c8c087f999419d20a193cd7a73e20d2616063816f91a2034ed8efcdecdeba7L27-R28) [[4]](diffhunk://#diff-3c51f1453da1de93dc14c4708598e65409bd6386e879b13b8225f4c6f9056aa5L7-R15) [[5]](diffhunk://#diff-3c51f1453da1de93dc14c4708598e65409bd6386e879b13b8225f4c6f9056aa5L44-R42) [[6]](diffhunk://#diff-3c51f1453da1de93dc14c4708598e65409bd6386e879b13b8225f4c6f9056aa5L55-L63) [[7]](diffhunk://#diff-5f00de31fa09a4ac4b8bf1c93ff0f72158ccdd64e7bea12f94b9efefeb532614L7-R7) [[8]](diffhunk://#diff-5f00de31fa09a4ac4b8bf1c93ff0f72158ccdd64e7bea12f94b9efefeb532614L16-R16) [[9]](diffhunk://#diff-5f00de31fa09a4ac4b8bf1c93ff0f72158ccdd64e7bea12f94b9efefeb532614L30-L42) [[10]](diffhunk://#diff-a261896c473adfb5dbc01cbb2cfb39cb610ecc0f5450b8041a7d36023747eb37L6-L26)

**MCP Protocol Improvements:**

* Updated MCP handlers to utilize the `Service` for module data retrieval and media control, improving error handling and simplifying the logic. [[1]](diffhunk://#diff-e7febec730ebfe62bef27e9f612321eaa531076bc050bcb5ba344b4dc96a4231L53-R55) [[2]](diffhunk://#diff-e7febec730ebfe62bef27e9f612321eaa531076bc050bcb5ba344b4dc96a4231L87-R98)

These changes collectively improve code organization, facilitate future enhancements, and ensure a single point of logic for key backend operations.