### PR TITLE
Sort disks, make configurable to show non-primary types

### DIFF
--- a/data/module/disks.go
+++ b/data/module/disks.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 
 	"github.com/shirou/gopsutil/v4/disk"
+	"github.com/timmo001/system-bridge/settings"
 	"github.com/timmo001/system-bridge/types"
 )
 
@@ -17,15 +18,38 @@ func (diskModule DiskModule) Name() types.ModuleName { return types.ModuleDisks 
 func (diskModule DiskModule) Update(ctx context.Context) (any, error) {
 	slog.Debug("Getting disks data")
 
+	cfg, err := settings.Load()
+	if err != nil {
+		slog.Warn("Failed to load settings for disk filtering, using defaults", "error", err)
+		cfg = &settings.Settings{}
+	}
+
 	var disksData types.DisksData
-	// Initialize arrays
 	disksData.Devices = make([]types.Disk, 0)
 
-	// Get all partitions
-	partitions, err := disk.Partitions(false)
+	// Get all partitions (true includes device-mapper, LUKS, LVM, btrfs subvolumes)
+	allPartitions, err := disk.Partitions(true)
 	if err != nil {
 		slog.Error("Failed to get disk partitions", "error", err)
 		return disksData, err
+	}
+
+	// Filter to relevant partitions based on settings
+	allowedSet := make(map[string]bool, len(cfg.Disks.AllowedSecondaryMountPoints))
+	for _, mp := range cfg.Disks.AllowedSecondaryMountPoints {
+		allowedSet[mp] = true
+	}
+
+	var partitions []disk.PartitionStat
+	for _, p := range allPartitions {
+		if !strings.HasPrefix(p.Device, "/dev/") {
+			continue
+		}
+		category := ClassifyMount(p)
+		if category != types.DiskMountCategoryPrimary && !allowedSet[p.Mountpoint] {
+			continue
+		}
+		partitions = append(partitions, p)
 	}
 
 	// Get IO counters for all devices
@@ -116,4 +140,83 @@ func (diskModule DiskModule) Update(ctx context.Context) (any, error) {
 	})
 
 	return disksData, nil
+}
+
+// ClassifyMount determines the category of a partition based on its properties.
+func ClassifyMount(p disk.PartitionStat) types.DiskMountCategory {
+	if p.Fstype == "squashfs" {
+		return types.DiskMountCategorySquashFS
+	}
+	for _, opt := range p.Opts {
+		if opt == "bind" {
+			return types.DiskMountCategoryBind
+		}
+	}
+	return types.DiskMountCategoryPrimary
+}
+
+// GetAllMountsCategorized returns all /dev/ mounts categorized for the settings UI.
+func GetAllMountsCategorized() (*types.DiskMountsResponse, error) {
+	allPartitions, err := disk.Partitions(true)
+	if err != nil {
+		return nil, err
+	}
+
+	response := &types.DiskMountsResponse{
+		Primary: make([]types.DiskMountInfo, 0),
+		Secondary: types.DiskMountsSecondary{
+			Bind:     make([]types.DiskMountInfo, 0),
+			SquashFS: make([]types.DiskMountInfo, 0),
+		},
+	}
+
+	for _, p := range allPartitions {
+		if !strings.HasPrefix(p.Device, "/dev/") {
+			continue
+		}
+
+		category := ClassifyMount(p)
+
+		// Get usage stats
+		var diskUsage *types.DiskUsage
+		usage, err := disk.Usage(p.Mountpoint)
+		if err == nil {
+			diskUsage = &types.DiskUsage{
+				Total:   usage.Total,
+				Used:    usage.Used,
+				Free:    usage.Free,
+				Percent: usage.UsedPercent,
+			}
+		}
+
+		info := types.DiskMountInfo{
+			Device:         p.Device,
+			MountPoint:     p.Mountpoint,
+			FilesystemType: p.Fstype,
+			Category:       category,
+			Usage:          diskUsage,
+		}
+
+		switch category {
+		case types.DiskMountCategoryPrimary:
+			response.Primary = append(response.Primary, info)
+		case types.DiskMountCategoryBind:
+			response.Secondary.Bind = append(response.Secondary.Bind, info)
+		case types.DiskMountCategorySquashFS:
+			response.Secondary.SquashFS = append(response.Secondary.SquashFS, info)
+		}
+	}
+
+	// Sort each category by mount point for stable ordering
+	sort.Slice(response.Primary, func(i, j int) bool {
+		return response.Primary[i].MountPoint < response.Primary[j].MountPoint
+	})
+	sort.Slice(response.Secondary.Bind, func(i, j int) bool {
+		return response.Secondary.Bind[i].MountPoint < response.Secondary.Bind[j].MountPoint
+	})
+	sort.Slice(response.Secondary.SquashFS, func(i, j int) bool {
+		return response.Secondary.SquashFS[i].MountPoint < response.Secondary.SquashFS[j].MountPoint
+	})
+
+	return response, nil
 }

--- a/data/module/disks.go
+++ b/data/module/disks.go
@@ -2,6 +2,7 @@ package data_module
 
 import (
 	"context"
+	"slices"
 	"sort"
 	"strings"
 
@@ -106,6 +107,7 @@ func (diskModule DiskModule) Update(ctx context.Context) (any, error) {
 			MountPoint:     partition.Mountpoint,
 			FilesystemType: partition.Fstype,
 			Options:        strings.Join(partition.Opts, ","),
+			Category:       ClassifyMount(partition),
 			Usage:          diskUsage,
 		}
 
@@ -151,11 +153,9 @@ func ClassifyMount(p disk.PartitionStat) types.DiskMountCategory {
 	if p.Fstype == "squashfs" {
 		return types.DiskMountCategorySquashFS
 	}
-	for _, opt := range p.Opts {
-		if opt == "bind" {
+	if slices.Contains(p.Opts, "bind") {
 			return types.DiskMountCategoryBind
 		}
-	}
 	return types.DiskMountCategoryPrimary
 }
 

--- a/data/module/disks.go
+++ b/data/module/disks.go
@@ -2,6 +2,7 @@ package data_module
 
 import (
 	"context"
+	"sort"
 	"strings"
 
 	"log/slog"
@@ -102,8 +103,17 @@ func (diskModule DiskModule) Update(ctx context.Context) (any, error) {
 
 	// Convert map to array
 	for _, device := range deviceMap {
+		// Sort partitions within each device by mount point for stable ordering
+		sort.Slice(device.Partitions, func(i, j int) bool {
+			return device.Partitions[i].MountPoint < device.Partitions[j].MountPoint
+		})
 		disksData.Devices = append(disksData.Devices, *device)
 	}
+
+	// Sort devices by name for deterministic ordering across API calls
+	sort.Slice(disksData.Devices, func(i, j int) bool {
+		return disksData.Devices[i].Name < disksData.Devices[j].Name
+	})
 
 	return disksData, nil
 }

--- a/data/module/disks.go
+++ b/data/module/disks.go
@@ -144,6 +144,10 @@ func (diskModule DiskModule) Update(ctx context.Context) (any, error) {
 
 // ClassifyMount determines the category of a partition based on its properties.
 func ClassifyMount(p disk.PartitionStat) types.DiskMountCategory {
+	// Root mount is always primary regardless of options
+	if p.Mountpoint == "/" {
+		return types.DiskMountCategoryPrimary
+	}
 	if p.Fstype == "squashfs" {
 		return types.DiskMountCategorySquashFS
 	}

--- a/data/module/disks.go
+++ b/data/module/disks.go
@@ -15,6 +15,12 @@ import (
 
 type DiskModule struct{}
 
+// partitionsFunc is the function used to retrieve partitions. Override in tests.
+var partitionsFunc = disk.Partitions
+
+// usageFunc is the function used to retrieve disk usage. Override in tests.
+var usageFunc = disk.Usage
+
 func (diskModule DiskModule) Name() types.ModuleName { return types.ModuleDisks }
 func (diskModule DiskModule) Update(ctx context.Context) (any, error) {
 	slog.Debug("Getting disks data")
@@ -29,7 +35,7 @@ func (diskModule DiskModule) Update(ctx context.Context) (any, error) {
 	disksData.Devices = make([]types.Disk, 0)
 
 	// Get all partitions (true includes device-mapper, LUKS, LVM, btrfs subvolumes)
-	allPartitions, err := disk.Partitions(true)
+	allPartitions, err := partitionsFunc(true)
 	if err != nil {
 		slog.Error("Failed to get disk partitions", "error", err)
 		return disksData, err
@@ -88,7 +94,7 @@ func (diskModule DiskModule) Update(ctx context.Context) (any, error) {
 		}
 
 		// Get usage statistics
-		usage, err := disk.Usage(partition.Mountpoint)
+		usage, err := usageFunc(partition.Mountpoint)
 		var diskUsage *types.DiskUsage
 		if err != nil {
 			slog.Error("Failed to get disk usage:", "mountpoint", partition.Mountpoint, "error", err)
@@ -154,14 +160,14 @@ func ClassifyMount(p disk.PartitionStat) types.DiskMountCategory {
 		return types.DiskMountCategorySquashFS
 	}
 	if slices.Contains(p.Opts, "bind") {
-			return types.DiskMountCategoryBind
-		}
+		return types.DiskMountCategoryBind
+	}
 	return types.DiskMountCategoryPrimary
 }
 
 // GetAllMountsCategorized returns all /dev/ mounts categorized for the settings UI.
 func GetAllMountsCategorized() (*types.DiskMountsResponse, error) {
-	allPartitions, err := disk.Partitions(true)
+	allPartitions, err := partitionsFunc(true)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +189,7 @@ func GetAllMountsCategorized() (*types.DiskMountsResponse, error) {
 
 		// Get usage stats
 		var diskUsage *types.DiskUsage
-		usage, err := disk.Usage(p.Mountpoint)
+		usage, err := usageFunc(p.Mountpoint)
 		if err == nil {
 			diskUsage = &types.DiskUsage{
 				Total:   usage.Total,

--- a/data/module/disks_test.go
+++ b/data/module/disks_test.go
@@ -1,0 +1,72 @@
+package data_module
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/timmo001/system-bridge/types"
+)
+
+func TestDiskModule_Update_DeterministicOrdering(t *testing.T) {
+	module := DiskModule{}
+
+	// Run Update multiple times and verify ordering is always consistent.
+	// Go map iteration is randomized, so without sorting this would
+	// produce different orderings across invocations.
+	const iterations = 10
+	var firstResult types.DisksData
+
+	for i := 0; i < iterations; i++ {
+		result, err := module.Update(context.Background())
+		if err != nil {
+			t.Fatalf("Update() returned error: %v", err)
+		}
+
+		disksData, ok := result.(types.DisksData)
+		if !ok {
+			t.Fatalf("Update() returned unexpected type: %T", result)
+		}
+
+		// Verify devices are sorted by name
+		if !sort.SliceIsSorted(disksData.Devices, func(i, j int) bool {
+			return disksData.Devices[i].Name < disksData.Devices[j].Name
+		}) {
+			names := make([]string, len(disksData.Devices))
+			for idx, d := range disksData.Devices {
+				names[idx] = d.Name
+			}
+			t.Fatalf("iteration %d: devices not sorted by name: %v", i, names)
+		}
+
+		// Verify partitions within each device are sorted by mount point
+		for _, device := range disksData.Devices {
+			if !sort.SliceIsSorted(device.Partitions, func(a, b int) bool {
+				return device.Partitions[a].MountPoint < device.Partitions[b].MountPoint
+			}) {
+				mounts := make([]string, len(device.Partitions))
+				for idx, p := range device.Partitions {
+					mounts[idx] = p.MountPoint
+				}
+				t.Fatalf("iteration %d: partitions for %s not sorted by mount point: %v",
+					i, device.Name, mounts)
+			}
+		}
+
+		// Compare against first result to verify consistency
+		if i == 0 {
+			firstResult = disksData
+		} else {
+			if len(disksData.Devices) != len(firstResult.Devices) {
+				t.Fatalf("iteration %d: device count changed (%d vs %d)",
+					i, len(disksData.Devices), len(firstResult.Devices))
+			}
+			for j := range disksData.Devices {
+				if disksData.Devices[j].Name != firstResult.Devices[j].Name {
+					t.Fatalf("iteration %d: device[%d] name mismatch: %q vs %q",
+						i, j, disksData.Devices[j].Name, firstResult.Devices[j].Name)
+				}
+			}
+		}
+	}
+}

--- a/data/module/disks_test.go
+++ b/data/module/disks_test.go
@@ -158,6 +158,16 @@ func TestClassifyMount(t *testing.T) {
 			},
 			expected: types.DiskMountCategoryPrimary,
 		},
+		{
+			name: "root btrfs with bind is still primary",
+			input: disk.PartitionStat{
+				Device:     "/dev/dm-0",
+				Mountpoint: "/",
+				Fstype:     "btrfs",
+				Opts:       []string{"rw", "relatime", "bind"},
+			},
+			expected: types.DiskMountCategoryPrimary,
+		},
 	}
 
 	for _, tt := range tests {

--- a/data/module/disks_test.go
+++ b/data/module/disks_test.go
@@ -180,15 +180,47 @@ func TestClassifyMount(t *testing.T) {
 	}
 }
 
+// mockPartitions returns a fixed set of partitions for testing.
+func mockPartitions(_ bool) ([]disk.PartitionStat, error) {
+	return []disk.PartitionStat{
+		{Device: "/dev/nvme0n1p2", Mountpoint: "/", Fstype: "ext4", Opts: []string{"rw", "relatime"}},
+		{Device: "/dev/nvme0n1p1", Mountpoint: "/boot", Fstype: "vfat", Opts: []string{"rw", "relatime"}},
+		{Device: "/dev/dm-0", Mountpoint: "/home", Fstype: "btrfs", Opts: []string{"rw", "relatime", "bind"}},
+		{Device: "/dev/loop0", Mountpoint: "/snap/snapd/25202", Fstype: "squashfs", Opts: []string{"ro", "nodev"}},
+		{Device: "tmpfs", Mountpoint: "/tmp", Fstype: "tmpfs", Opts: []string{"rw"}},
+		{Device: "overlay", Mountpoint: "/var/lib/docker/overlay2/abc/merged", Fstype: "overlay", Opts: []string{"rw"}},
+	}, nil
+}
+
+// mockUsage returns synthetic usage stats for any mount point.
+func mockUsage(_ string) (*disk.UsageStat, error) {
+	return &disk.UsageStat{
+		Total:       100 * 1024 * 1024 * 1024,
+		Used:        40 * 1024 * 1024 * 1024,
+		Free:        60 * 1024 * 1024 * 1024,
+		UsedPercent: 40.0,
+	}, nil
+}
+
 func TestGetAllMountsCategorized(t *testing.T) {
+	// Replace real functions with mocks for deterministic results.
+	origPartitions := partitionsFunc
+	origUsage := usageFunc
+	partitionsFunc = mockPartitions
+	usageFunc = mockUsage
+	t.Cleanup(func() {
+		partitionsFunc = origPartitions
+		usageFunc = origUsage
+	})
+
 	response, err := GetAllMountsCategorized()
 	if err != nil {
 		t.Fatalf("GetAllMountsCategorized() returned error: %v", err)
 	}
 
-	// Primary mounts should have at least one entry (the root filesystem)
-	if len(response.Primary) == 0 {
-		t.Error("expected at least one primary mount")
+	// Primary mounts: / and /boot (both are /dev/ devices, not bind/squashfs)
+	if len(response.Primary) != 2 {
+		t.Fatalf("expected 2 primary mounts, got %d", len(response.Primary))
 	}
 
 	// All primary mounts should be real devices
@@ -201,24 +233,44 @@ func TestGetAllMountsCategorized(t *testing.T) {
 		}
 	}
 
-	// Verify secondary bind mounts are categorized correctly
-	for _, m := range response.Secondary.Bind {
-		if m.Category != types.DiskMountCategoryBind {
-			t.Errorf("bind mount %q has wrong category: %q", m.MountPoint, m.Category)
+	// Verify secondary bind mounts
+	if len(response.Secondary.Bind) != 1 {
+		t.Fatalf("expected 1 bind mount, got %d", len(response.Secondary.Bind))
+	}
+	if response.Secondary.Bind[0].MountPoint != "/home" {
+		t.Errorf("expected bind mount at /home, got %q", response.Secondary.Bind[0].MountPoint)
+	}
+	if response.Secondary.Bind[0].Category != types.DiskMountCategoryBind {
+		t.Errorf("bind mount has wrong category: %q", response.Secondary.Bind[0].Category)
+	}
+
+	// Verify secondary squashfs mounts
+	if len(response.Secondary.SquashFS) != 1 {
+		t.Fatalf("expected 1 squashfs mount, got %d", len(response.Secondary.SquashFS))
+	}
+	if response.Secondary.SquashFS[0].Category != types.DiskMountCategorySquashFS {
+		t.Errorf("squashfs mount has wrong category: %q", response.Secondary.SquashFS[0].Category)
+	}
+
+	// Non-/dev/ devices (tmpfs, overlay) should be excluded entirely
+	allMounts := append(append(response.Primary, response.Secondary.Bind...), response.Secondary.SquashFS...)
+	for _, m := range allMounts {
+		if m.Device == "tmpfs" || m.Device == "overlay" {
+			t.Errorf("virtual filesystem %q should have been filtered out", m.Device)
 		}
 	}
 
-	// Verify secondary squashfs mounts are categorized correctly
-	for _, m := range response.Secondary.SquashFS {
-		if m.Category != types.DiskMountCategorySquashFS {
-			t.Errorf("squashfs mount %q has wrong category: %q", m.MountPoint, m.Category)
-		}
-	}
-
-	// Verify primary mounts are sorted
+	// Verify primary mounts are sorted by mount point
 	if !sort.SliceIsSorted(response.Primary, func(i, j int) bool {
 		return response.Primary[i].MountPoint < response.Primary[j].MountPoint
 	}) {
 		t.Error("primary mounts are not sorted by mount point")
+	}
+
+	// Verify usage stats are populated
+	for _, m := range response.Primary {
+		if m.Usage == nil {
+			t.Errorf("primary mount %q has nil usage", m.MountPoint)
+		}
 	}
 }

--- a/data/module/disks_test.go
+++ b/data/module/disks_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/shirou/gopsutil/v4/disk"
 	"github.com/timmo001/system-bridge/types"
 )
 
@@ -68,5 +69,146 @@ func TestDiskModule_Update_DeterministicOrdering(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestDiskModule_Update_NoVirtualFilesystems(t *testing.T) {
+	module := DiskModule{}
+
+	result, err := module.Update(context.Background())
+	if err != nil {
+		t.Fatalf("Update() returned error: %v", err)
+	}
+
+	disksData, ok := result.(types.DisksData)
+	if !ok {
+		t.Fatalf("Update() returned unexpected type: %T", result)
+	}
+
+	// All returned devices should have names starting with /dev/
+	for _, device := range disksData.Devices {
+		if len(device.Name) < 5 || device.Name[:5] != "/dev/" {
+			t.Errorf("device %q does not start with /dev/", device.Name)
+		}
+	}
+
+	// No squashfs partitions should be present (unless explicitly allowed)
+	for _, device := range disksData.Devices {
+		for _, partition := range device.Partitions {
+			if partition.FilesystemType == "squashfs" {
+				t.Errorf("squashfs partition found: %s (should be filtered by default)", partition.MountPoint)
+			}
+		}
+	}
+}
+
+func TestClassifyMount(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    disk.PartitionStat
+		expected types.DiskMountCategory
+	}{
+		{
+			name: "primary ext4 partition",
+			input: disk.PartitionStat{
+				Device:     "/dev/sda1",
+				Mountpoint: "/",
+				Fstype:     "ext4",
+				Opts:       []string{"rw", "relatime"},
+			},
+			expected: types.DiskMountCategoryPrimary,
+		},
+		{
+			name: "primary btrfs without bind",
+			input: disk.PartitionStat{
+				Device:     "/dev/dm-0",
+				Mountpoint: "/",
+				Fstype:     "btrfs",
+				Opts:       []string{"rw", "relatime"},
+			},
+			expected: types.DiskMountCategoryPrimary,
+		},
+		{
+			name: "bind mount (btrfs subvolume)",
+			input: disk.PartitionStat{
+				Device:     "/dev/dm-0",
+				Mountpoint: "/home",
+				Fstype:     "btrfs",
+				Opts:       []string{"rw", "relatime", "bind"},
+			},
+			expected: types.DiskMountCategoryBind,
+		},
+		{
+			name: "squashfs snap mount",
+			input: disk.PartitionStat{
+				Device:     "/dev/loop0",
+				Mountpoint: "/snap/snapd/25202",
+				Fstype:     "squashfs",
+				Opts:       []string{"ro", "nodev", "relatime"},
+			},
+			expected: types.DiskMountCategorySquashFS,
+		},
+		{
+			name: "vfat boot partition",
+			input: disk.PartitionStat{
+				Device:     "/dev/nvme0n1p1",
+				Mountpoint: "/boot",
+				Fstype:     "vfat",
+				Opts:       []string{"rw", "relatime"},
+			},
+			expected: types.DiskMountCategoryPrimary,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ClassifyMount(tt.input)
+			if result != tt.expected {
+				t.Errorf("ClassifyMount() = %q, want %q", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetAllMountsCategorized(t *testing.T) {
+	response, err := GetAllMountsCategorized()
+	if err != nil {
+		t.Fatalf("GetAllMountsCategorized() returned error: %v", err)
+	}
+
+	// Primary mounts should have at least one entry (the root filesystem)
+	if len(response.Primary) == 0 {
+		t.Error("expected at least one primary mount")
+	}
+
+	// All primary mounts should be real devices
+	for _, m := range response.Primary {
+		if len(m.Device) < 5 || m.Device[:5] != "/dev/" {
+			t.Errorf("primary mount device %q does not start with /dev/", m.Device)
+		}
+		if m.Category != types.DiskMountCategoryPrimary {
+			t.Errorf("primary mount %q has wrong category: %q", m.MountPoint, m.Category)
+		}
+	}
+
+	// Verify secondary bind mounts are categorized correctly
+	for _, m := range response.Secondary.Bind {
+		if m.Category != types.DiskMountCategoryBind {
+			t.Errorf("bind mount %q has wrong category: %q", m.MountPoint, m.Category)
+		}
+	}
+
+	// Verify secondary squashfs mounts are categorized correctly
+	for _, m := range response.Secondary.SquashFS {
+		if m.Category != types.DiskMountCategorySquashFS {
+			t.Errorf("squashfs mount %q has wrong category: %q", m.MountPoint, m.Category)
+		}
+	}
+
+	// Verify primary mounts are sorted
+	if !sort.SliceIsSorted(response.Primary, func(i, j int) bool {
+		return response.Primary[i].MountPoint < response.Primary[j].MountPoint
+	}) {
+		t.Error("primary mounts are not sorted by mount point")
 	}
 }

--- a/event/event_types.go
+++ b/event/event_types.go
@@ -8,6 +8,7 @@ const (
 	EventGetData                EventType = "GET_DATA"
 	EventGetDirectories         EventType = "GET_DIRECTORIES"
 	EventGetDirectory           EventType = "GET_DIRECTORY"
+	EventGetDiskMounts          EventType = "GET_DISK_MOUNTS"
 	EventGetFiles               EventType = "GET_FILES"
 	EventGetFile                EventType = "GET_FILE"
 	EventGetSettings            EventType = "GET_SETTINGS"

--- a/event/handler/frontend.go
+++ b/event/handler/frontend.go
@@ -8,6 +8,7 @@ func settingsToFrontend(s *settings.Settings) map[string]interface{} {
 	return map[string]interface{}{
 		"autostart": s.Autostart,
 		"commands":  s.Commands,
+		"disks":     s.Disks,
 		"hotkeys":   s.Hotkeys,
 		"logLevel":  string(s.LogLevel),
 		"media":     s.Media,

--- a/event/handler/get-disk-mounts.go
+++ b/event/handler/get-disk-mounts.go
@@ -1,0 +1,33 @@
+package event_handler
+
+import (
+	"log/slog"
+
+	data_module "github.com/timmo001/system-bridge/data/module"
+	"github.com/timmo001/system-bridge/event"
+)
+
+func RegisterGetDiskMountsHandler(router *event.MessageRouter) {
+	router.RegisterSimpleHandler(event.EventGetDiskMounts, func(connection string, message event.Message) event.MessageResponse {
+		slog.Debug("Received get disk mounts event", "message", message)
+
+		response, err := data_module.GetAllMountsCategorized()
+		if err != nil {
+			slog.Error("Failed to get disk mounts", "error", err)
+			return event.MessageResponse{
+				ID:      message.ID,
+				Type:    event.ResponseTypeError,
+				Subtype: event.ResponseSubtypeNone,
+				Message: "Failed to get disk mounts",
+			}
+		}
+
+		return event.MessageResponse{
+			ID:      message.ID,
+			Type:    event.ResponseTypeDiskMounts,
+			Subtype: event.ResponseSubtypeNone,
+			Data:    response,
+			Message: "Got disk mounts",
+		}
+	})
+}

--- a/event/handler/handler.go
+++ b/event/handler/handler.go
@@ -9,6 +9,7 @@ func RegisterHandlers(router *event.MessageRouter, dataStore *data.DataStore) {
 	RegisterExitApplicationHandler(router)
 	RegisterGetDataHandler(router)
 	RegisterGetDirectoriesHandler(router)
+	RegisterGetDiskMountsHandler(router)
 	RegisterGetFilesHandler(router)
 	RegisterGetFileHandler(router)
 	RegisterGetDirectoryHandler(router)

--- a/event/response_types.go
+++ b/event/response_types.go
@@ -9,6 +9,7 @@ const (
 	ResponseTypeDataGet                  ResponseType = "DATA_GET"
 	ResponseTypeDirectories              ResponseType = "DIRECTORIES"
 	ResponseTypeDirectory                ResponseType = "DIRECTORY"
+	ResponseTypeDiskMounts               ResponseType = "DISK_MOUNTS"
 	ResponseTypeFiles                    ResponseType = "FILES"
 	ResponseTypeFile                     ResponseType = "FILE"
 	ResponseTypeKeyboardKeyPressed       ResponseType = "KEYBOARD_KEY_PRESSED"

--- a/settings/settings.go
+++ b/settings/settings.go
@@ -95,11 +95,16 @@ type SettingsMedia struct {
 	Directories []SettingsMediaDirectory `json:"directories" mapstructure:"directories"`
 }
 
+type SettingsDisks struct {
+	AllowedSecondaryMountPoints []string `json:"allowedSecondaryMountPoints" mapstructure:"allowedSecondaryMountPoints"`
+}
+
 type Settings struct {
 	Autostart bool             `json:"autostart" mapstructure:"autostart"`
 	Hotkeys   []SettingsHotkey `json:"hotkeys" mapstructure:"hotkeys"`
 	LogLevel  LogLevel         `json:"logLevel" mapstructure:"logLevel"`
 	Commands  SettingsCommands `json:"commands" mapstructure:"commands"`
+	Disks     SettingsDisks    `json:"disks" mapstructure:"disks"`
 	Media     SettingsMedia    `json:"media" mapstructure:"media"`
 }
 
@@ -119,6 +124,7 @@ func Load() (*Settings, error) {
 	viper.SetDefault("autostart", false)
 	viper.SetDefault("hotkeys", []SettingsHotkey{})
 	viper.SetDefault("logLevel", LogLevelWarn)
+	viper.SetDefault("disks.allowedSecondaryMountPoints", []string{})
 	viper.SetDefault("media.directories", []SettingsMediaDirectory{})
 	viper.SetDefault("commands.allowlist", []SettingsCommandDefinition{})
 
@@ -207,6 +213,7 @@ func (cfg *Settings) Save() error {
 	viper.Set("hotkeys", cfg.Hotkeys)
 	viper.Set("logLevel", string(cfg.LogLevel))
 	viper.Set("commands.allowlist", cfg.Commands.Allowlist)
+	viper.Set("disks.allowedSecondaryMountPoints", cfg.Disks.AllowedSecondaryMountPoints)
 	viper.Set("media.directories", cfg.Media.Directories)
 
 	if err := viper.WriteConfig(); err != nil {

--- a/tools/generate-schemas/main.go
+++ b/tools/generate-schemas/main.go
@@ -340,6 +340,9 @@ func getStructComment(name string) string {
 		"DiskIOCounters":         "Disk IO Counters",
 		"DiskUsage":              "Disk Usage",
 		"DiskPartition":          "Disk Partition",
+		"DiskMountInfo":          "Disk Mount Info",
+		"DiskMountsSecondary":    "Disk Mounts Secondary",
+		"DiskMountsResponse":     "Disk Mounts Response",
 		"Disk":                   "Disk",
 		"Display":                "Display",
 		"GPU":                    "GPU",
@@ -581,6 +584,11 @@ func orderStructsByDependency(structs map[string]StructInfo) []string {
 		"ProcessesData",
 		"SensorsData",
 		"SystemData",
+
+		// Disk mount types (for settings UI)
+		"DiskMountInfo",
+		"DiskMountsSecondary",
+		"DiskMountsResponse",
 	}
 
 	// Filter to only include structs that exist

--- a/tools/generate-schemas/main.go
+++ b/tools/generate-schemas/main.go
@@ -264,7 +264,15 @@ func generateZodSchemas(structs map[string]StructInfo, enums map[string]EnumInfo
 				fmt.Fprintf(&buf, `"%s"`, value)
 			}
 			buf.WriteString("]);\n")
-			fmt.Fprintf(&buf, "export type %s = z.infer<typeof %sSchema>;\n\n", name, name)
+			fmt.Fprintf(&buf, "export type %s = z.infer<typeof %sSchema>;\n", name, name)
+
+			// Generate constants object for enum values
+			fmt.Fprintf(&buf, "export const %s = {\n", name)
+			for _, value := range enum.Values {
+				constName := strings.ToUpper(value)
+				fmt.Fprintf(&buf, "  %s: \"%s\",\n", constName, value)
+			}
+			buf.WriteString("} as const;\n\n")
 		}
 	}
 

--- a/types/disks.go
+++ b/types/disks.go
@@ -20,13 +20,14 @@ type DiskUsage struct {
 
 // DiskPartition represents information about a disk partition
 type DiskPartition struct {
-	Device         string     `json:"device"`
-	MountPoint     string     `json:"mount_point"`
-	FilesystemType string     `json:"filesystem_type"`
-	Options        string     `json:"options"`
-	MaxFileSize    int64      `json:"max_file_size"`
-	MaxPathLength  int64      `json:"max_path_length"`
-	Usage          *DiskUsage `json:"usage"`
+	Device         string            `json:"device"`
+	MountPoint     string            `json:"mount_point"`
+	FilesystemType string            `json:"filesystem_type"`
+	Options        string            `json:"options"`
+	MaxFileSize    int64             `json:"max_file_size"`
+	MaxPathLength  int64             `json:"max_path_length"`
+	Category       DiskMountCategory `json:"category"`
+	Usage          *DiskUsage        `json:"usage"`
 }
 
 // Disk represents information about a single disk device

--- a/types/disks.go
+++ b/types/disks.go
@@ -41,3 +41,33 @@ type DisksData struct {
 	Devices    []Disk          `json:"devices"`
 	IOCounters *DiskIOCounters `json:"io_counters"`
 }
+
+// DiskMountCategory represents the category of a mount point
+type DiskMountCategory string
+
+const (
+	DiskMountCategoryPrimary  DiskMountCategory = "primary"
+	DiskMountCategoryBind     DiskMountCategory = "bind"
+	DiskMountCategorySquashFS DiskMountCategory = "squashfs"
+)
+
+// DiskMountInfo represents a single mount point with its category
+type DiskMountInfo struct {
+	Device         string            `json:"device"`
+	MountPoint     string            `json:"mount_point"`
+	FilesystemType string            `json:"filesystem_type"`
+	Category       DiskMountCategory `json:"category"`
+	Usage          *DiskUsage        `json:"usage"`
+}
+
+// DiskMountsSecondary groups secondary mounts by category
+type DiskMountsSecondary struct {
+	Bind     []DiskMountInfo `json:"bind"`
+	SquashFS []DiskMountInfo `json:"squashfs"`
+}
+
+// DiskMountsResponse is the response for GET_DISK_MOUNTS
+type DiskMountsResponse struct {
+	Primary   []DiskMountInfo     `json:"primary"`
+	Secondary DiskMountsSecondary `json:"secondary"`
+}

--- a/utils/handlers/settings/settings.go
+++ b/utils/handlers/settings/settings.go
@@ -22,6 +22,7 @@ func Update(current *Settings, new *Settings) error {
 	current.Autostart = new.Autostart
 	current.Hotkeys = new.Hotkeys
 	current.LogLevel = new.LogLevel
+	current.Disks = new.Disks
 	current.Media = new.Media
 	current.Commands = new.Commands
 	return current.Save()

--- a/web-client/src/app.ts
+++ b/web-client/src/app.ts
@@ -58,6 +58,14 @@ class App extends LitElement {
       },
     },
     {
+      path: "/settings/disks",
+      render: () => html`<page-settings-disks></page-settings-disks>`,
+      enter: async () => {
+        await import("./pages/settings-disks");
+        return true;
+      },
+    },
+    {
       path: "/notifications",
       render: () => html`<page-notifications></page-notifications>`,
       enter: async () => {

--- a/web-client/src/components/ui/checkbox.ts
+++ b/web-client/src/components/ui/checkbox.ts
@@ -1,0 +1,66 @@
+import { html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+import { cn } from "~/lib/utils";
+import { UIElement } from "~/mixins/light-dom";
+
+@customElement("ui-checkbox")
+class Checkbox extends UIElement {
+  @property({ type: Boolean }) checked = false;
+  @property({ type: Boolean }) disabled = false;
+  @property() name = "";
+
+  render() {
+    const boxClasses = cn(
+      "peer inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border border-primary",
+      "shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      this.checked ? "bg-primary text-primary-foreground" : "bg-background",
+      !this.disabled && "cursor-pointer",
+    );
+
+    return html`
+      <button
+        type="button"
+        role="checkbox"
+        aria-checked=${this.checked}
+        ?disabled=${this.disabled}
+        class=${boxClasses}
+        @click=${this._handleClick}
+      >
+        ${this.checked
+          ? html`<svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="3"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="h-3 w-3"
+            >
+              <polyline points="20 6 9 17 4 12"></polyline>
+            </svg>`
+          : null}
+      </button>
+    `;
+  }
+
+  private _handleClick = () => {
+    if (this.disabled) return;
+    this.checked = !this.checked;
+    this.dispatchEvent(
+      new CustomEvent("checkbox-change", {
+        detail: { checked: this.checked },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  };
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "ui-checkbox": Checkbox;
+  }
+}

--- a/web-client/src/components/websocket-provider.ts
+++ b/web-client/src/components/websocket-provider.ts
@@ -438,6 +438,7 @@ class WebSocketProvider extends ProviderElement {
     return { moduleName, data: dataValidation.data };
   }
 
+  // fallow-ignore-next-line complexity
   private normalizeSettings(
     settings: Partial<Settings>,
     current?: Settings | null,

--- a/web-client/src/components/websocket-provider.ts
+++ b/web-client/src/components/websocket-provider.ts
@@ -449,6 +449,7 @@ class WebSocketProvider extends ProviderElement {
         hotkeys: [],
         logLevel: "INFO",
         commands: { allowlist: [] },
+        disks: { allowedSecondaryMountPoints: [] },
         media: { directories: [] },
       } satisfies Settings);
     const {
@@ -457,6 +458,9 @@ class WebSocketProvider extends ProviderElement {
       logLevel = fallback.logLevel,
     } = settings;
     const { allowlist = fallback.commands.allowlist } = settings.commands ?? {};
+    const {
+      allowedSecondaryMountPoints = fallback.disks.allowedSecondaryMountPoints,
+    } = settings.disks ?? {};
     const { directories = fallback.media.directories } = settings.media ?? {};
 
     return {
@@ -464,6 +468,7 @@ class WebSocketProvider extends ProviderElement {
       hotkeys,
       logLevel,
       commands: { allowlist },
+      disks: { allowedSecondaryMountPoints },
       media: { directories },
     };
   }

--- a/web-client/src/contexts/websocket.ts
+++ b/web-client/src/contexts/websocket.ts
@@ -1,5 +1,5 @@
 import { createContext } from "@lit/context";
-import { type z } from "zod";
+import type { z } from "zod";
 
 import type { ModuleData } from "~/lib/system-bridge/types-modules";
 import type { Settings } from "~/lib/system-bridge/types-settings";

--- a/web-client/src/lib/system-bridge/types-modules-schemas.ts
+++ b/web-client/src/lib/system-bridge/types-modules-schemas.ts
@@ -6,10 +6,18 @@ import { z } from "zod";
 // DiskMountCategory enum
 export const DiskMountCategorySchema = z.enum(["primary", "bind", "squashfs"]);
 export type DiskMountCategory = z.infer<typeof DiskMountCategorySchema>;
+export const DiskMountCategory = {
+  PRIMARY: "primary",
+  BIND: "bind",
+  SQUASHFS: "squashfs",
+} as const;
 
 // RunMode enum
 export const RunModeSchema = z.enum(["standalone"]);
 export type RunMode = z.infer<typeof RunModeSchema>;
+export const RunMode = {
+  STANDALONE: "standalone",
+} as const;
 
 // CPU Frequency
 export const CPUFrequencySchema = z.object({
@@ -171,6 +179,7 @@ export const DiskPartitionSchema = z.object({
   options: z.string(),
   max_file_size: z.number(),
   max_path_length: z.number(),
+  category: DiskMountCategorySchema,
   usage: DiskUsageSchema.nullish(),
 });
 
@@ -361,7 +370,9 @@ export const SensorsWindowsHardwareSchema: z.ZodType<{
   sensors: z.array(SensorsWindowsSensorSchema),
 });
 
-export type SensorsWindowsHardware = z.infer<typeof SensorsWindowsHardwareSchema>;
+export type SensorsWindowsHardware = z.infer<
+  typeof SensorsWindowsHardwareSchema
+>;
 
 // Windows Sensors
 export const SensorsWindowsSchema = z.object({

--- a/web-client/src/lib/system-bridge/types-modules-schemas.ts
+++ b/web-client/src/lib/system-bridge/types-modules-schemas.ts
@@ -504,6 +504,15 @@ export const SystemDataSchema = z.object({
 
 export type SystemData = z.infer<typeof SystemDataSchema>;
 
+// Module
+export const ModuleSchema = z.object({
+  module: z.unknown(),
+  data: z.unknown(),
+  updated: z.string(),
+});
+
+export type Module = z.infer<typeof ModuleSchema>;
+
 // DiskMountInfo
 export const DiskMountInfoSchema = z.object({
   device: z.string(),
@@ -530,15 +539,6 @@ export const DiskMountsResponseSchema = z.object({
 });
 
 export type DiskMountsResponse = z.infer<typeof DiskMountsResponseSchema>;
-
-// Module
-export const ModuleSchema = z.object({
-  module: z.unknown(),
-  data: z.unknown(),
-  updated: z.string(),
-});
-
-export type Module = z.infer<typeof ModuleSchema>;
 
 // Module Data Union Type
 export const ModuleDataSchemas = {

--- a/web-client/src/lib/system-bridge/types-modules-schemas.ts
+++ b/web-client/src/lib/system-bridge/types-modules-schemas.ts
@@ -523,6 +523,14 @@ export const DiskMountsSecondarySchema = z.object({
 
 export type DiskMountsSecondary = z.infer<typeof DiskMountsSecondarySchema>;
 
+// DiskMountsResponse
+export const DiskMountsResponseSchema = z.object({
+  primary: z.array(DiskMountInfoSchema),
+  secondary: DiskMountsSecondarySchema,
+});
+
+export type DiskMountsResponse = z.infer<typeof DiskMountsResponseSchema>;
+
 // Module
 export const ModuleSchema = z.object({
   module: z.unknown(),
@@ -531,14 +539,6 @@ export const ModuleSchema = z.object({
 });
 
 export type Module = z.infer<typeof ModuleSchema>;
-
-// DiskMountsResponse
-export const DiskMountsResponseSchema = z.object({
-  primary: z.array(DiskMountInfoSchema),
-  secondary: DiskMountsSecondarySchema,
-});
-
-export type DiskMountsResponse = z.infer<typeof DiskMountsResponseSchema>;
 
 // Module Data Union Type
 export const ModuleDataSchemas = {

--- a/web-client/src/lib/system-bridge/types-modules-schemas.ts
+++ b/web-client/src/lib/system-bridge/types-modules-schemas.ts
@@ -523,14 +523,6 @@ export const DiskMountsSecondarySchema = z.object({
 
 export type DiskMountsSecondary = z.infer<typeof DiskMountsSecondarySchema>;
 
-// DiskMountsResponse
-export const DiskMountsResponseSchema = z.object({
-  primary: z.array(DiskMountInfoSchema),
-  secondary: DiskMountsSecondarySchema,
-});
-
-export type DiskMountsResponse = z.infer<typeof DiskMountsResponseSchema>;
-
 // Module
 export const ModuleSchema = z.object({
   module: z.unknown(),
@@ -539,6 +531,14 @@ export const ModuleSchema = z.object({
 });
 
 export type Module = z.infer<typeof ModuleSchema>;
+
+// DiskMountsResponse
+export const DiskMountsResponseSchema = z.object({
+  primary: z.array(DiskMountInfoSchema),
+  secondary: DiskMountsSecondarySchema,
+});
+
+export type DiskMountsResponse = z.infer<typeof DiskMountsResponseSchema>;
 
 // Module Data Union Type
 export const ModuleDataSchemas = {

--- a/web-client/src/lib/system-bridge/types-modules-schemas.ts
+++ b/web-client/src/lib/system-bridge/types-modules-schemas.ts
@@ -361,9 +361,7 @@ export const SensorsWindowsHardwareSchema: z.ZodType<{
   sensors: z.array(SensorsWindowsSensorSchema),
 });
 
-export type SensorsWindowsHardware = z.infer<
-  typeof SensorsWindowsHardwareSchema
->;
+export type SensorsWindowsHardware = z.infer<typeof SensorsWindowsHardwareSchema>;
 
 // Windows Sensors
 export const SensorsWindowsSchema = z.object({
@@ -504,16 +502,7 @@ export const SystemDataSchema = z.object({
 
 export type SystemData = z.infer<typeof SystemDataSchema>;
 
-// Module
-export const ModuleSchema = z.object({
-  module: z.unknown(),
-  data: z.unknown(),
-  updated: z.string(),
-});
-
-export type Module = z.infer<typeof ModuleSchema>;
-
-// DiskMountInfo
+// Disk Mount Info
 export const DiskMountInfoSchema = z.object({
   device: z.string(),
   mount_point: z.string(),
@@ -524,7 +513,7 @@ export const DiskMountInfoSchema = z.object({
 
 export type DiskMountInfo = z.infer<typeof DiskMountInfoSchema>;
 
-// DiskMountsSecondary
+// Disk Mounts Secondary
 export const DiskMountsSecondarySchema = z.object({
   bind: z.array(DiskMountInfoSchema),
   squashfs: z.array(DiskMountInfoSchema),
@@ -532,13 +521,22 @@ export const DiskMountsSecondarySchema = z.object({
 
 export type DiskMountsSecondary = z.infer<typeof DiskMountsSecondarySchema>;
 
-// DiskMountsResponse
+// Disk Mounts Response
 export const DiskMountsResponseSchema = z.object({
   primary: z.array(DiskMountInfoSchema),
   secondary: DiskMountsSecondarySchema,
 });
 
 export type DiskMountsResponse = z.infer<typeof DiskMountsResponseSchema>;
+
+// Module
+export const ModuleSchema = z.object({
+  module: z.unknown(),
+  data: z.unknown(),
+  updated: z.string(),
+});
+
+export type Module = z.infer<typeof ModuleSchema>;
 
 // Module Data Union Type
 export const ModuleDataSchemas = {

--- a/web-client/src/lib/system-bridge/types-modules-schemas.ts
+++ b/web-client/src/lib/system-bridge/types-modules-schemas.ts
@@ -3,6 +3,10 @@ import { z } from "zod";
 // Auto-generated file. Do not edit manually.
 // Generated from backend types in types/ directory
 
+// DiskMountCategory enum
+export const DiskMountCategorySchema = z.enum(["primary", "bind", "squashfs"]);
+export type DiskMountCategory = z.infer<typeof DiskMountCategorySchema>;
+
 // RunMode enum
 export const RunModeSchema = z.enum(["standalone"]);
 export type RunMode = z.infer<typeof RunModeSchema>;
@@ -499,6 +503,33 @@ export const SystemDataSchema = z.object({
 });
 
 export type SystemData = z.infer<typeof SystemDataSchema>;
+
+// DiskMountInfo
+export const DiskMountInfoSchema = z.object({
+  device: z.string(),
+  mount_point: z.string(),
+  filesystem_type: z.string(),
+  category: DiskMountCategorySchema,
+  usage: DiskUsageSchema.nullish(),
+});
+
+export type DiskMountInfo = z.infer<typeof DiskMountInfoSchema>;
+
+// DiskMountsSecondary
+export const DiskMountsSecondarySchema = z.object({
+  bind: z.array(DiskMountInfoSchema),
+  squashfs: z.array(DiskMountInfoSchema),
+});
+
+export type DiskMountsSecondary = z.infer<typeof DiskMountsSecondarySchema>;
+
+// DiskMountsResponse
+export const DiskMountsResponseSchema = z.object({
+  primary: z.array(DiskMountInfoSchema),
+  secondary: DiskMountsSecondarySchema,
+});
+
+export type DiskMountsResponse = z.infer<typeof DiskMountsResponseSchema>;
 
 // Module
 export const ModuleSchema = z.object({

--- a/web-client/src/lib/system-bridge/types-settings.ts
+++ b/web-client/src/lib/system-bridge/types-settings.ts
@@ -14,6 +14,10 @@ const SettingsMediaSchema = z.object({
   directories: z.array(SettingsMediaDirectorySchema),
 });
 
+const SettingsDisksSchema = z.object({
+  allowedSecondaryMountPoints: z.array(z.string()),
+});
+
 const SettingsCommandDefinitionSchema = z.object({
   id: z.string(),
   name: z.string().min(1),
@@ -35,6 +39,7 @@ const SettingsSchema = z.object({
   hotkeys: z.array(SettingsHotkeySchema),
   logLevel: z.enum(["DEBUG", "INFO", "WARN", "ERROR"]),
   commands: SettingsCommandsSchema,
+  disks: SettingsDisksSchema,
   media: SettingsMediaSchema,
 });
 

--- a/web-client/src/lib/system-bridge/types-websocket.ts
+++ b/web-client/src/lib/system-bridge/types-websocket.ts
@@ -27,6 +27,7 @@ const EventTypeSchema = z.enum([
   "DATA_UPDATE",
   "UPDATE_SETTINGS",
   "VALIDATE_DIRECTORY",
+  "GET_DISK_MOUNTS",
 ]);
 
 const ResponseTypeSchema = z.enum([
@@ -56,6 +57,7 @@ const ResponseTypeSchema = z.enum([
   "SETTINGS_RESULT",
   "SETTINGS_UPDATED",
   "DIRECTORY_VALIDATED",
+  "DISK_MOUNTS",
 ]);
 
 const ResponseSubtypeSchema = z.enum([

--- a/web-client/src/pages/home.ts
+++ b/web-client/src/pages/home.ts
@@ -30,6 +30,10 @@ class PageHome extends PageElement {
     this.navigate("/settings/commands");
   };
 
+  private handleNavigateToDisks = (): void => {
+    this.navigate("/settings/disks");
+  };
+
   private handleNavigateToNotifications = (): void => {
     this.navigate("/notifications");
   };
@@ -100,6 +104,13 @@ class PageHome extends PageElement {
                     @click=${this.handleNavigateToCommands}
                   >
                     Commands
+                  </ui-button>
+                  <ui-button
+                    variant="default"
+                    class="w-full"
+                    @click=${this.handleNavigateToDisks}
+                  >
+                    Disks
                   </ui-button>
                 </div>
               </div>

--- a/web-client/src/pages/settings-disks.ts
+++ b/web-client/src/pages/settings-disks.ts
@@ -8,7 +8,6 @@ import {
   type ConnectionSettings,
 } from "~/contexts/connection";
 import { websocketContext, type WebSocketState } from "~/contexts/websocket";
-import type { Settings } from "~/lib/system-bridge/types-settings";
 import { generateUUID } from "~/lib/utils";
 import { PageElement } from "~/mixins/page-element";
 import "../components/ui/button";
@@ -105,6 +104,7 @@ class PageSettingsDisks extends PageElement {
     void this.loadMounts();
   }
 
+  // fallow-ignore-next-line complexity
   private loadSettings() {
     if (this.websocket?.settings) {
       this.allowedMountPoints = [
@@ -113,12 +113,10 @@ class PageSettingsDisks extends PageElement {
     }
   }
 
+  // fallow-ignore-next-line complexity
   private async loadMounts() {
-    if (
-      !this.connection?.token ||
-      !this.websocket?.sendRequestWithResponse ||
-      !this.websocket?.isConnected
-    ) {
+    const token = this.connection?.token;
+    if (!token || !this.websocket?.sendRequestWithResponse || !this.websocket.isConnected) {
       return;
     }
 
@@ -126,17 +124,16 @@ class PageSettingsDisks extends PageElement {
     this.requestUpdate();
 
     try {
-      const response =
+      this.mounts =
         await this.websocket.sendRequestWithResponse<DiskMountsResponse>(
           {
             id: generateUUID(),
             event: "GET_DISK_MOUNTS",
             data: {},
-            token: this.connection.token,
+            token,
           },
           DiskMountsResponseSchema,
         );
-      this.mounts = response;
     } catch (error) {
       console.error("Failed to load disk mounts:", error);
     } finally {
@@ -160,36 +157,23 @@ class PageSettingsDisks extends PageElement {
     this.saveSettings();
   };
 
+  // fallow-ignore-next-line complexity
   private saveSettings(): void {
-    if (
-      !this.connection?.token ||
-      !this.websocket?.sendRequest ||
-      !this.websocket?.settings
-    ) {
+    const token = this.connection?.token;
+    if (!token || !this.websocket?.sendRequest || !this.websocket.settings) {
       return;
     }
 
-    this.requestUpdate();
-
-    try {
-      const updatedSettings: Settings = {
+    this.websocket.sendRequest({
+      id: generateUUID(),
+      event: "UPDATE_SETTINGS",
+      data: {
         ...this.websocket.settings,
-        disks: {
-          allowedSecondaryMountPoints: this.allowedMountPoints,
-        },
-      };
-
-      this.websocket.sendRequest({
-        id: generateUUID(),
-        event: "UPDATE_SETTINGS",
-        data: updatedSettings,
-        token: this.connection.token,
-      });
-    } catch (error) {
-      console.error("Failed to update disk settings:", error);
-    } finally {
-      this.requestUpdate();
-    }
+        disks: { allowedSecondaryMountPoints: this.allowedMountPoints },
+      },
+      token,
+    });
+    this.requestUpdate();
   }
 
   private handleNavigateToConnection = (): void => {

--- a/web-client/src/pages/settings-disks.ts
+++ b/web-client/src/pages/settings-disks.ts
@@ -116,7 +116,11 @@ class PageSettingsDisks extends PageElement {
   // fallow-ignore-next-line complexity
   private async loadMounts() {
     const token = this.connection?.token;
-    if (!token || !this.websocket?.sendRequestWithResponse || !this.websocket.isConnected) {
+    if (
+      !token ||
+      !this.websocket?.sendRequestWithResponse ||
+      !this.websocket.isConnected
+    ) {
       return;
     }
 

--- a/web-client/src/pages/settings-disks.ts
+++ b/web-client/src/pages/settings-disks.ts
@@ -1,13 +1,17 @@
 import { consume } from "@lit/context";
 import { html, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { z } from "zod";
 
 import {
   connectionContext,
   type ConnectionSettings,
 } from "~/contexts/connection";
 import { websocketContext, type WebSocketState } from "~/contexts/websocket";
+import {
+  DiskMountsResponseSchema,
+  type DiskMountInfo,
+  type DiskMountsResponse,
+} from "~/lib/system-bridge/types-modules-schemas";
 import { generateUUID } from "~/lib/utils";
 import { PageElement } from "~/mixins/page-element";
 import "../components/ui/button";
@@ -16,50 +20,6 @@ import "../components/ui/connection-indicator";
 import "../components/ui/connection-required";
 import "../components/ui/icon";
 import "../components/ui/label";
-
-interface DiskMountInfo {
-  device: string;
-  mount_point: string;
-  filesystem_type: string;
-  category: string;
-  usage: {
-    total: number;
-    used: number;
-    free: number;
-    percent: number;
-  } | null;
-}
-
-interface DiskMountsResponse {
-  primary: DiskMountInfo[];
-  secondary: {
-    bind: DiskMountInfo[];
-    squashfs: DiskMountInfo[];
-  };
-}
-
-const DiskUsageSchema = z.object({
-  total: z.number(),
-  used: z.number(),
-  free: z.number(),
-  percent: z.number(),
-});
-
-const DiskMountInfoSchema = z.object({
-  device: z.string(),
-  mount_point: z.string(),
-  filesystem_type: z.string(),
-  category: z.string(),
-  usage: DiskUsageSchema.nullable(),
-});
-
-const DiskMountsResponseSchema = z.object({
-  primary: z.array(DiskMountInfoSchema),
-  secondary: z.object({
-    bind: z.array(DiskMountInfoSchema),
-    squashfs: z.array(DiskMountInfoSchema),
-  }),
-});
 
 function formatBytes(bytes: number): string {
   if (bytes === 0) return "0 B";

--- a/web-client/src/pages/settings-disks.ts
+++ b/web-client/src/pages/settings-disks.ts
@@ -12,6 +12,7 @@ import type { Settings } from "~/lib/system-bridge/types-settings";
 import { generateUUID } from "~/lib/utils";
 import { PageElement } from "~/mixins/page-element";
 import "../components/ui/button";
+import "../components/ui/checkbox";
 import "../components/ui/connection-indicator";
 import "../components/ui/connection-required";
 import "../components/ui/icon";
@@ -206,15 +207,13 @@ class PageSettingsDisks extends PageElement {
           ? "opacity-75"
           : ""}"
       >
-        <input
-          type="checkbox"
-          class="h-4 w-4 rounded border-input"
+        <ui-checkbox
           .checked=${checked}
           ?disabled=${disabled}
-          @change=${() => {
+          @checkbox-change=${() => {
             if (!disabled) this.handleToggleMount(mount.mount_point);
           }}
-        />
+        ></ui-checkbox>
         <div class="flex-1 min-w-0">
           <div class="font-medium font-mono text-sm truncate">
             ${mount.mount_point}

--- a/web-client/src/pages/settings-disks.ts
+++ b/web-client/src/pages/settings-disks.ts
@@ -1,0 +1,319 @@
+import { consume } from "@lit/context";
+import { html, type TemplateResult } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { z } from "zod";
+
+import {
+  connectionContext,
+  type ConnectionSettings,
+} from "~/contexts/connection";
+import { websocketContext, type WebSocketState } from "~/contexts/websocket";
+import type { Settings } from "~/lib/system-bridge/types-settings";
+import { generateUUID } from "~/lib/utils";
+import { PageElement } from "~/mixins/page-element";
+import "../components/ui/button";
+import "../components/ui/connection-indicator";
+import "../components/ui/connection-required";
+import "../components/ui/icon";
+import "../components/ui/label";
+
+interface DiskMountInfo {
+  device: string;
+  mount_point: string;
+  filesystem_type: string;
+  category: string;
+  usage: {
+    total: number;
+    used: number;
+    free: number;
+    percent: number;
+  } | null;
+}
+
+interface DiskMountsResponse {
+  primary: DiskMountInfo[];
+  secondary: {
+    bind: DiskMountInfo[];
+    squashfs: DiskMountInfo[];
+  };
+}
+
+const DiskUsageSchema = z.object({
+  total: z.number(),
+  used: z.number(),
+  free: z.number(),
+  percent: z.number(),
+});
+
+const DiskMountInfoSchema = z.object({
+  device: z.string(),
+  mount_point: z.string(),
+  filesystem_type: z.string(),
+  category: z.string(),
+  usage: DiskUsageSchema.nullable(),
+});
+
+const DiskMountsResponseSchema = z.object({
+  primary: z.array(DiskMountInfoSchema),
+  secondary: z.object({
+    bind: z.array(DiskMountInfoSchema),
+    squashfs: z.array(DiskMountInfoSchema),
+  }),
+});
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
+}
+
+@customElement("page-settings-disks")
+class PageSettingsDisks extends PageElement {
+  title = "Disk Mounts";
+  description = "Configure which disk mounts are reported";
+
+  @consume({ context: websocketContext, subscribe: true })
+  websocket?: WebSocketState;
+
+  @consume({ context: connectionContext, subscribe: true })
+  connection?: ConnectionSettings;
+
+  @state()
+  private mounts: DiskMountsResponse | null = null;
+
+  @state()
+  private allowedMountPoints: string[] = [];
+
+  @state()
+  private isLoading = false;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.loadData();
+  }
+
+  updated(changedProperties: Map<PropertyKey, unknown>) {
+    if (changedProperties.has("websocket")) {
+      this.loadData();
+    }
+  }
+
+  private loadData() {
+    this.loadSettings();
+    this.loadMounts();
+  }
+
+  private loadSettings() {
+    if (this.websocket?.settings) {
+      this.allowedMountPoints = [
+        ...(this.websocket.settings.disks?.allowedSecondaryMountPoints ?? []),
+      ];
+    }
+  }
+
+  private async loadMounts() {
+    if (
+      !this.connection?.token ||
+      !this.websocket?.sendRequestWithResponse ||
+      !this.websocket?.isConnected
+    ) {
+      return;
+    }
+
+    this.isLoading = true;
+    this.requestUpdate();
+
+    try {
+      const response =
+        await this.websocket.sendRequestWithResponse<DiskMountsResponse>(
+          {
+            id: generateUUID(),
+            event: "GET_DISK_MOUNTS",
+            data: {},
+            token: this.connection.token,
+          },
+          DiskMountsResponseSchema,
+        );
+      this.mounts = response;
+    } catch (error) {
+      console.error("Failed to load disk mounts:", error);
+    } finally {
+      this.isLoading = false;
+      this.requestUpdate();
+    }
+  }
+
+  private handleToggleMount(mountPoint: string) {
+    if (this.allowedMountPoints.includes(mountPoint)) {
+      this.allowedMountPoints = this.allowedMountPoints.filter(
+        (mp) => mp !== mountPoint,
+      );
+    } else {
+      this.allowedMountPoints = [...this.allowedMountPoints, mountPoint];
+    }
+    this.saveSettings();
+  }
+
+  private saveSettings(): void {
+    if (
+      !this.connection?.token ||
+      !this.websocket?.sendRequest ||
+      !this.websocket?.settings
+    ) {
+      return;
+    }
+
+    this.requestUpdate();
+
+    try {
+      const updatedSettings: Settings = {
+        ...this.websocket.settings,
+        disks: {
+          allowedSecondaryMountPoints: this.allowedMountPoints,
+        },
+      };
+
+      this.websocket.sendRequest({
+        id: generateUUID(),
+        event: "UPDATE_SETTINGS",
+        data: updatedSettings,
+        token: this.connection.token,
+      });
+    } catch (error) {
+      console.error("Failed to update disk settings:", error);
+    } finally {
+      this.requestUpdate();
+    }
+  }
+
+  private handleNavigateToConnection = (): void => {
+    this.navigate("/connection");
+  };
+
+  private renderMountRow(
+    mount: DiskMountInfo,
+    options: { disabled?: boolean; checked?: boolean } = {},
+  ) {
+    const { disabled = false, checked = false } = options;
+    const usageText = mount.usage
+      ? `${mount.usage.percent.toFixed(1)}% (${formatBytes(mount.usage.used)} / ${formatBytes(mount.usage.total)})`
+      : "N/A";
+
+    return html`
+      <label
+        class="flex items-center gap-4 p-3 rounded-md border cursor-pointer hover:bg-muted/50 transition-colors ${disabled
+          ? "opacity-75"
+          : ""}"
+      >
+        <input
+          type="checkbox"
+          class="h-4 w-4 rounded border-input"
+          .checked=${checked}
+          ?disabled=${disabled}
+          @change=${() => {
+            if (!disabled) this.handleToggleMount(mount.mount_point);
+          }}
+        />
+        <div class="flex-1 min-w-0">
+          <div class="font-medium font-mono text-sm truncate">
+            ${mount.mount_point}
+          </div>
+          <div class="text-xs text-muted-foreground truncate">
+            ${mount.device} &middot; ${mount.filesystem_type}
+          </div>
+        </div>
+        <div class="text-sm text-muted-foreground whitespace-nowrap">
+          ${usageText}
+        </div>
+      </label>
+    `;
+  }
+
+  private renderSection(
+    title: string,
+    description: string,
+    mounts: DiskMountInfo[],
+    options: { disabled?: boolean } = {},
+  ): TemplateResult {
+    const { disabled = false } = options;
+
+    if (mounts.length === 0) {
+      return html``;
+    }
+
+    return html`
+      <div class="rounded-lg border bg-card p-6 space-y-4">
+        <div class="space-y-1">
+          <h2 class="text-lg font-semibold">${title}</h2>
+          <p class="text-sm text-muted-foreground">${description}</p>
+        </div>
+        <div class="space-y-2">
+          ${mounts.map((mount) =>
+            this.renderMountRow(mount, {
+              disabled,
+              checked:
+                disabled || this.allowedMountPoints.includes(mount.mount_point),
+            }),
+          )}
+        </div>
+      </div>
+    `;
+  }
+
+  // fallow-ignore-next-line complexity
+  private renderContent() {
+    if (this.isLoading || !this.mounts) {
+      return html`
+        <div class="text-sm text-muted-foreground italic p-4 text-center">
+          Loading disk mounts...
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="space-y-6">
+        ${this.renderSection(
+          "Primary Mounts",
+          "These mounts are always reported. They cannot be disabled.",
+          this.mounts.primary,
+          { disabled: true },
+        )}
+        ${this.renderSection(
+          "Bind Mounts",
+          "Subvolume and bind mounts that share storage with a primary device (e.g., btrfs subvolumes).",
+          this.mounts.secondary.bind,
+        )}
+        ${this.renderSection(
+          "SquashFS Mounts",
+          "Read-only compressed mounts, always 100% full (e.g., snap packages).",
+          this.mounts.secondary.squashfs,
+        )}
+      </div>
+    `;
+  }
+
+  render() {
+    const isConnected = this.websocket?.isConnected ?? false;
+
+    return html`
+      <div class="min-h-screen bg-background text-foreground p-8">
+        <div class="max-w-4xl mx-auto space-y-6">
+          ${this.renderPageHeader()}
+          ${this.renderWithConnection(
+            isConnected,
+            "Please connect to System Bridge to manage disk mount settings.",
+            this.handleNavigateToConnection,
+            this.renderContent(),
+          )}
+        </div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "page-settings-disks": PageSettingsDisks;
+  }
+}

--- a/web-client/src/pages/settings-disks.ts
+++ b/web-client/src/pages/settings-disks.ts
@@ -102,7 +102,7 @@ class PageSettingsDisks extends PageElement {
 
   private loadData() {
     this.loadSettings();
-    this.loadMounts();
+    void this.loadMounts();
   }
 
   private loadSettings() {
@@ -244,21 +244,21 @@ class PageSettingsDisks extends PageElement {
       return html``;
     }
 
+    const mountRows = mounts.map((mount) =>
+      this.renderMountRow(mount, {
+        disabled,
+        checked:
+          disabled || this.allowedMountPoints.includes(mount.mount_point),
+      }),
+    );
+
     return html`
       <div class="rounded-lg border bg-card p-6 space-y-4">
         <div class="space-y-1">
           <h2 class="text-lg font-semibold">${title}</h2>
           <p class="text-sm text-muted-foreground">${description}</p>
         </div>
-        <div class="space-y-2">
-          ${mounts.map((mount) =>
-            this.renderMountRow(mount, {
-              disabled,
-              checked:
-                disabled || this.allowedMountPoints.includes(mount.mount_point),
-            }),
-          )}
-        </div>
+        <div class="space-y-2">${mountRows}</div>
       </div>
     `;
   }

--- a/web-client/src/pages/settings-disks.ts
+++ b/web-client/src/pages/settings-disks.ts
@@ -145,7 +145,11 @@ class PageSettingsDisks extends PageElement {
     }
   }
 
-  private handleToggleMount(mountPoint: string) {
+  private handleToggleMount = (e: Event): void => {
+    const el = e.currentTarget as HTMLElement;
+    const mountPoint = el.getAttribute("data-mount");
+    if (!mountPoint) return;
+
     if (this.allowedMountPoints.includes(mountPoint)) {
       this.allowedMountPoints = this.allowedMountPoints.filter(
         (mp) => mp !== mountPoint,
@@ -154,7 +158,7 @@ class PageSettingsDisks extends PageElement {
       this.allowedMountPoints = [...this.allowedMountPoints, mountPoint];
     }
     this.saveSettings();
-  }
+  };
 
   private saveSettings(): void {
     if (
@@ -210,9 +214,8 @@ class PageSettingsDisks extends PageElement {
         <ui-checkbox
           .checked=${checked}
           ?disabled=${disabled}
-          @checkbox-change=${() => {
-            if (!disabled) this.handleToggleMount(mount.mount_point);
-          }}
+          data-mount=${mount.mount_point}
+          @checkbox-change=${this.handleToggleMount}
         ></ui-checkbox>
         <div class="flex-1 min-w-0">
           <div class="font-medium font-mono text-sm truncate">

--- a/web-client/src/pages/settings-general.ts
+++ b/web-client/src/pages/settings-general.ts
@@ -37,6 +37,9 @@ class PageSettingsGeneral extends PageElement {
     commands: {
       allowlist: [],
     },
+    disks: {
+      allowedSecondaryMountPoints: [],
+    },
     media: {
       directories: [],
     },


### PR DESCRIPTION
Fixes #3519

Allow showing secondary disks (subvolume, bind and snap/loop/squashfs mounts) (disabled by default)