### PR TITLE
Make mise optional for source builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-# OS detection
-MISE=mise exec --
+# Use mise if available; fall back to direct tool invocation for environments
+# without mise (e.g. Raspberry Pi source builds). Override with MISE= to force
+# direct invocation even when mise is installed.
+MISE := $(shell command -v mise >/dev/null 2>&1 && printf 'mise exec --')
 
 ifeq ($(OS),Windows_NT)
 	EXE=.exe
@@ -106,10 +108,10 @@ endif
 build_tui:
 	@echo "Building TUI..."
 ifeq ($(OS),Windows_NT)
-	cd tui && bun install --frozen-lockfile && bun build src/index.ts --compile --outfile ../system-bridge-tui.exe
+	cd tui && $(MISE) bun install --frozen-lockfile && $(MISE) bun build src/index.ts --compile --outfile ../system-bridge-tui.exe
 	@echo "TUI built: system-bridge-tui.exe"
 else
-	cd tui && bun install --frozen-lockfile && bun build src/index.ts --compile --outfile ../system-bridge-tui
+	cd tui && $(MISE) bun install --frozen-lockfile && $(MISE) bun build src/index.ts --compile --outfile ../system-bridge-tui
 	@echo "TUI built: system-bridge-tui"
 endif
 
@@ -149,7 +151,7 @@ install: build
 
 run: build
 	@echo "Starting web client and backend in parallel..."
-	cd web-client && $(MISE) pnpm exec concurrently -n "web,backend" -c "blue,green" "mise exec -- pnpm dev" "../$(OUT) backend"
+	cd web-client && $(MISE) pnpm exec concurrently -n "web,backend" -c "blue,green" "$(MISE) pnpm dev" "../$(OUT) backend"
 
 run-web-client:
 	cd web-client && $(MISE) pnpm dev

--- a/README.md
+++ b/README.md
@@ -34,11 +34,16 @@ See [installation documentation](https://system-bridge.timmo.dev/docs/install).
 
 ## Development Setup
 
-1. Install `mise`
+1. Install [`mise`](https://mise.jdx.dev/installing-mise.html) (recommended)
 1. Run `mise install` in the repo root to install the pinned Go, Node,
    and pnpm toolchains.
 
 `mise.toml` is the source of truth for local and CI runtimes.
+
+> **Building without mise:** If you cannot install `mise` (e.g. Raspberry Pi
+> armhf), ensure compatible versions of `go`, `node`, `pnpm`, and `bun` are on
+> your PATH. The Makefile auto-detects `mise` and falls back to invoking tools
+> directly when it is not available.
 
 ## Build and Install
 


### PR DESCRIPTION
Auto-detect mise on PATH and fall back to direct tool invocation when it is not available. This restores the ability to build from source on systems where mise cannot easily be installed (e.g. Raspberry Pi armhf).

- MISE variable now uses $(shell command -v mise ...) detection
- build_tui target routed through $(MISE) wrapper for consistency
- Hardcoded 'mise exec --' in run target replaced with $(MISE)
- README updated to document building without mise

Fixes #3938