### PR TITLE
docs: document SYSTEM_BRIDGE environment variables and file locations

### DIFF
--- a/docs/src/content/docs/developing.mdx
+++ b/docs/src/content/docs/developing.mdx
@@ -153,7 +153,7 @@ During development, settings and tokens use the same per-user locations as a nor
 | Windows | `%LOCALAPPDATA%\system-bridge\v5\` | `%LOCALAPPDATA%\system-bridge\logs\YYYY-MM-DD.log` |
 | macOS | `~/Library/Application Support/system-bridge/v5/` | `~/Library/Logs/system-bridge/YYYY-MM-DD.log` |
 
-The backend port defaults to `9170` and can be overridden with `SYSTEM_BRIDGE_PORT`.
+The backend port defaults to `9170` and can be overridden with `SYSTEM_BRIDGE_PORT`. The SSDP discovery port defaults to `1900` and can be overridden with `SYSTEM_BRIDGE_SSDP_PORT`. Override the settings and log directories with `SYSTEM_BRIDGE_CONFIG_DIR` and `SYSTEM_BRIDGE_LOG_DIR` (both must be absolute paths). See [Running → Configuration](/running/#configuration) for the full list of environment variables.
 
 ## Next steps
 

--- a/docs/src/content/docs/running.mdx
+++ b/docs/src/content/docs/running.mdx
@@ -216,6 +216,42 @@ Once built, start System Bridge from a terminal:
 system-bridge backend
 ```
 
+## Configuration
+
+### Environment variables
+
+System Bridge reads the following environment variables at startup. All are optional and fall back to the defaults below.
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SYSTEM_BRIDGE_PORT` | `9170` | Port for the HTTP and WebSocket API. Must be between `1` and `65535`; invalid values fall back to the default. |
+| `SYSTEM_BRIDGE_SSDP_PORT` | `1900` | Port used for SSDP network discovery. Must be between `1` and `65535`; invalid values fall back to the default. |
+| `SYSTEM_BRIDGE_CONFIG_DIR` | Per-OS path (see [File locations](#file-locations)) | Absolute path to override the directory holding settings, the token and stored data. |
+| `SYSTEM_BRIDGE_LOG_DIR` | Per-OS path (see [File locations](#file-locations)) | Absolute path to override the directory where log files are written. |
+
+:::note
+`SYSTEM_BRIDGE_CONFIG_DIR` and `SYSTEM_BRIDGE_LOG_DIR` must be absolute paths, otherwise the backend fails to start.
+:::
+
+When running as a systemd service, set variables with `Environment=` lines in the unit file, for example:
+
+```ini
+[Service]
+Environment="SYSTEM_BRIDGE_PORT=9171"
+```
+
+### File locations
+
+By default, settings, the token and logs are stored in per-user directories:
+
+| Platform | Settings / token / data | Logs |
+| --- | --- | --- |
+| Linux | `~/.local/share/system-bridge/v5/` | `~/.local/state/system-bridge/YYYY-MM-DD.log` |
+| Windows | `%LOCALAPPDATA%\system-bridge\v5\` | `%LOCALAPPDATA%\system-bridge\logs\YYYY-MM-DD.log` |
+| macOS | `~/Library/Application Support/system-bridge/v5/` | `~/Library/Logs/system-bridge/YYYY-MM-DD.log` |
+
+The token is stored as a `token` file inside the settings directory. Override these locations with `SYSTEM_BRIDGE_CONFIG_DIR` and `SYSTEM_BRIDGE_LOG_DIR`.
+
 ## Next steps
 
 - Open the [web client](/using/web-client/) to monitor and control your system.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The backend reads several `SYSTEM_BRIDGE_*` environment variables that were not documented anywhere in the docs site. This adds documentation for them.

Previously undocumented variables read by the code:
- `SYSTEM_BRIDGE_SSDP_PORT` (`utils/port.go`) — SSDP discovery port (default `1900`)
- `SYSTEM_BRIDGE_CONFIG_DIR` (`utils/path.go`) — override settings/token/data directory
- `SYSTEM_BRIDGE_LOG_DIR` (`utils/path.go`) — override log directory

## Changes

- `docs/src/content/docs/running.mdx`: new **Configuration** section with an **Environment variables** table (all four `SYSTEM_BRIDGE_*` variables, defaults, and constraints) and a **File locations** table (per-OS settings/token/data and log paths).
- `docs/src/content/docs/developing.mdx`: extend the existing configuration note to mention `SYSTEM_BRIDGE_SSDP_PORT`, `SYSTEM_BRIDGE_CONFIG_DIR`, and `SYSTEM_BRIDGE_LOG_DIR`, linking to the new Running → Configuration section.

## Testing

- `bun run build` (docs) — passes; internal link validation reports all internal links valid, including the new `#configuration` / `#file-locations` anchors.
- Verified rendered output via the preview server.

[Environment variables table](https://cursor.com/agents/bc-e954f7cf-5f6a-40c5-9ada-a4768853b284/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frunning_env_variables.webp)
[File locations table](https://cursor.com/agents/bc-e954f7cf-5f6a-40c5-9ada-a4768853b284/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frunning_file_locations.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e954f7cf-5f6a-40c5-9ada-a4768853b284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e954f7cf-5f6a-40c5-9ada-a4768853b284"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

