### PR TITLE
Seperate play and pause media actions on Linux

### DIFF
--- a/utils/handlers/media/media_linux.go
+++ b/utils/handlers/media/media_linux.go
@@ -11,8 +11,10 @@ func control(action MediaAction) error {
 	var cmd *exec.Cmd
 
 	switch action {
-	case MediaActionPlay, MediaActionPause:
-		cmd = exec.Command("playerctl", "play-pause")
+	case MediaActionPlay:
+		cmd = exec.Command("playerctl", "play")
+	case MediaActionPause:
+		cmd = exec.Command("playerctl", "pause")
 	case MediaActionNext:
 		cmd = exec.Command("playerctl", "next")
 	case MediaActionPrevious:


### PR DESCRIPTION
I've noticed that when creating an automation in Home-Assistant that's supposed to pause all media players in an area, the media player from the system-bridge integration actually resumes playback if its already paused for example.

Checking the code it looks like the API is supposed to handle play and pause seperately, but right now it doesn't.

I don't know about Windows and Mac, but on Linux `playerctl` has separate play and pause commands, so we can just use those.